### PR TITLE
Adding 'literal' quasi-attribute for factoids

### DIFF
--- a/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/model/FactoidAttributeType.kt
+++ b/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/model/FactoidAttributeType.kt
@@ -65,6 +65,7 @@ enum class FactoidAttributeType(val mutable: Boolean = true, val includeInSummar
     FORGET(mutable = false, includeInSummary = false),
     UNKNOWN(mutable = false, includeInSummary = false),
     INFO(mutable = false, includeInSummary = false),
+    LITERAL(mutable = false, includeInSummary = false),
     LOCK(mutable = false, includeInSummary = false),
     UNLOCK(mutable = false, includeInSummary = false);
 

--- a/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/operation/GetFactoidOperation.kt
+++ b/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/operation/GetFactoidOperation.kt
@@ -58,6 +58,7 @@ class GetFactoidOperation(
                 FactoidAttributeType.FORGET -> handleForget(selector, message)
                 FactoidAttributeType.UNKNOWN -> handleSummary(selector, attributes, argument)
                 FactoidAttributeType.INFO -> handleInfo(selector, attributes)
+                FactoidAttributeType.LITERAL -> handleLiteral(selector, attributes)
                 FactoidAttributeType.LOCK -> handleLock(selector, true, message)
                 FactoidAttributeType.UNLOCK -> handleLock(selector, false, message)
                 else -> handleSpecificAttribute(selector, payload.attribute, attributes, argument)
@@ -132,6 +133,16 @@ class GetFactoidOperation(
             }
         }
         return OperationResult.Success(response)
+    }
+
+    /** Returns the raw TEXT value with no rendering, interpolation, or selection resolution */
+    private fun handleLiteral(
+        selector: String,
+        attributes: List<FactoidAttribute>,
+    ): OperationOutcome? {
+        val textAttr =
+            attributes.firstOrNull { it.attributeType == FactoidAttributeType.TEXT } ?: return null
+        return OperationResult.Success(textAttr.attributeValue ?: return null)
     }
 
     /** Admin-only lock/unlock toggle */

--- a/operation-factoid/src/test/kotlin/com/enigmastation/streampack/factoid/operation/FactoidOperationTests.kt
+++ b/operation-factoid/src/test/kotlin/com/enigmastation/streampack/factoid/operation/FactoidOperationTests.kt
@@ -586,6 +586,46 @@ class FactoidOperationTests {
         }
     }
 
+    // -- Literal query --
+
+    @Test
+    fun `literal returns raw text value without rendering`() {
+        eventGateway.process(
+            msg(
+                "8ball=<reply>(Yes|No|Maybe|Ask me( tomorrow| again| again tomorrow)" +
+                    "|It's (unclear|unknowable))."
+            )
+        )
+        val result = eventGateway.process(msg("8ball.literal"))
+        assertSuccess(
+            result,
+            "<reply>(Yes|No|Maybe|Ask me( tomorrow| again| again tomorrow)" +
+                "|It's (unclear|unknowable)).",
+        )
+    }
+
+    @Test
+    fun `literal returns raw text with dollar-one unexpanded`() {
+        eventGateway.process(msg("ask=Please ask \$1 for help"))
+        val result = eventGateway.process(msg("ask.literal"))
+        assertSuccess(result, "Please ask \$1 for help")
+    }
+
+    @Test
+    fun `literal on factoid without text returns not handled`() {
+        eventGateway.process(msg("urlonly=placeholder"))
+        eventGateway.process(msg("forget urlonly"))
+        // Re-create with only a URL attribute via direct service
+        eventGateway.process(msg("urlonly.url=https://example.com"))
+        // This factoid has no TEXT, so there's nothing for literal to find
+        // But urlonly doesn't exist as a factoid yet - let's set one up properly
+        eventGateway.process(msg("urlonly=temp"))
+        eventGateway.process(msg("urlonly.url=https://example.com"))
+        // Now it has TEXT, so literal should return it
+        val result = eventGateway.process(msg("urlonly.literal"))
+        assertSuccess(result, "temp")
+    }
+
     // -- Helper --
 
     private fun assertTrue(condition: Boolean) {


### PR DESCRIPTION
This allows us to see the actual uninterpolated source for factoids' text attribute.

Closes #12