### PR TITLE
Adding youtube title support

### DIFF
--- a/docs/urltitle-operation.md
+++ b/docs/urltitle-operation.md
@@ -1,0 +1,120 @@
+# URL Title Operation
+
+When a user posts a message containing URLs, this operation fetches the page title and reports it to the channel.
+Titles that are too similar to the URL itself (determined by Jaccard similarity) are suppressed to avoid noise.
+
+## Title Display
+
+This operation is **unaddressed** - it fires on ambient conversation without requiring a signal character or bot mention.
+
+**Priority:** 91 (runs late, after most other operations).
+
+**Behavior:**
+
+- Extracts all `http://` and `https://` URLs from the message.
+- Fetches each URL's HTML and extracts the title.
+- Title extraction priority: `og:title` meta tag, then `twitter:title` meta tag, then the `<title>` element.
+  The `og:title` tag is preferred because many sites (YouTube, for example) serve useless `<title>` content without JavaScript rendering, but include meaningful OpenGraph metadata for link sharing.
+- If a title's Jaccard similarity to the URL exceeds the configured threshold (default 0.3), it is suppressed.
+  This avoids reporting titles that just repeat the URL path.
+- URLs whose hosts are on the ignored list are skipped entirely.
+
+**Response example:**
+```
+joe mentioned a url: https://example.com/article ("The Actual Article Title")
+joe mentioned 2 urls: https://example.com/one ("First") and https://example.com/two ("Second")
+```
+
+## Manage Ignored Hosts
+
+Admin commands for managing which hosts are skipped during title fetching.
+This operation is **addressed**.
+
+**Syntax:**
+```
+url ignore list                 show a sample of ignored hosts
+url ignore add <hostname>       add a host to the ignore list
+url ignore delete <hostname>    remove a host from the ignore list
+```
+
+**Priority:** 50 (default).
+
+**Default ignored hosts:**
+
+- `bpa.st`, `dpaste.com`, `pastebin.com`, `pastebin.org` - paste sites whose titles are not meaningful.
+- `twitter.com`, `x.com` - see "Twitter/X.com Limitations" below.
+
+## Twitter/X.com Limitations
+
+Twitter/X.com URLs are ignored by default because there is no free method to extract tweet content programmatically.
+
+**Approaches investigated (February 2026):**
+
+| Approach | Result |
+|----------|--------|
+| Scraping x.com directly | Returns a JavaScript shell with no content; tweets render client-side only |
+| nitter.net proxy | Returns HTTP 200 with 0 bytes body (anti-bot measures) |
+| fxtwitter.com proxy | Redirects to x.com |
+| vxtwitter.com proxy | Redirects to x.com |
+| xcancel.com proxy | JavaScript bot challenge (BotD fingerprinting, service worker validation) |
+| Twitter API free tier | No free read access; the API moved to pay-per-use ($0.005/tweet) in January 2026 |
+
+If a free proxy or API tier becomes available in the future, support could be re-added.
+
+### Implementation Plan for Twitter API Support
+
+The `TitleFetcher` interface (`lib-core`) is a single method: `fetchTitle(url: String): String?`.
+Currently, `HtmlTitleFetcher` is the only implementation, injected into `UrlTitleService`.
+Adding Twitter support requires three pieces:
+
+**1. `TwitterApiTitleFetcher`** - a new `TitleFetcher` that handles twitter/x.com URLs via the Twitter v2 API.
+
+- Parse the tweet ID from the URL path (the numeric segment after `/status/`).
+- Call `GET https://api.twitter.com/2/tweets/{id}?expansions=author_id&user.fields=username,name&tweet.fields=text` with a Bearer token.
+- Compose the title as `@username: tweet text`.
+- The Bearer token comes from app-only OAuth 2.0 authentication (no user context needed for public tweets).
+
+**2. `CompositeTitleFetcher`** - a delegating `TitleFetcher` that routes by URL host.
+
+- If the host is `twitter.com`, `x.com`, or `www.` variants, delegate to `TwitterApiTitleFetcher`.
+- Otherwise, delegate to `HtmlTitleFetcher`.
+- This replaces `HtmlTitleFetcher` as the bean injected into `UrlTitleService`.
+- Marked `@Primary` so Spring picks it over `HtmlTitleFetcher` when both are present.
+
+**3. Conditional activation** - the composite fetcher and Twitter fetcher only activate when a bearer token is configured.
+
+```kotlin
+@Configuration
+@ConditionalOnProperty(prefix = "streampack.twitter", name = ["bearer-token"])
+class TwitterTitleConfiguration {
+    // creates TwitterApiTitleFetcher and CompositeTitleFetcher beans
+}
+```
+
+When the bearer token is absent, `HtmlTitleFetcher` remains the sole `TitleFetcher` and twitter/x.com stays on the ignored hosts list.
+When present, the composite fetcher takes over and twitter/x.com should be removed from the ignored hosts list (either manually via `url ignore delete` or by omitting them from `defaultIgnoredHosts` in the deployment's config).
+
+**Configuration properties:**
+
+| Property | Description |
+|----------|-------------|
+| `streampack.twitter.bearer-token` | Twitter API v2 Bearer token (enables Twitter title fetching when present) |
+
+**Cost estimate (pay-per-use, January 2026 pricing):**
+$0.005 per tweet read, with 24-hour deduplication.
+A small community channel seeing 20 twitter links per day would cost roughly $3/month.
+
+**No SDK dependency needed.**
+All maintained Java/Kotlin Twitter SDKs are either abandoned or unstable.
+A single `HttpClient` GET with a Bearer token header is simpler and more reliable than any SDK.
+The existing `HttpPageFetcher` pattern (Java `HttpClient`, gzip support, timeout handling) provides a template.
+
+## Configuration
+
+| Property | Default | Description |
+|----------|---------|-------------|
+| `streampack.urltitle.protocols` | IRC, DISCORD, SLACK, CONSOLE, MATTERMOST | Protocols on which title fetching is active |
+| `streampack.urltitle.defaultIgnoredHosts` | bpa.st, dpaste.com, pastebin.com, pastebin.org, twitter.com, x.com | Hosts seeded into the ignore list on startup |
+| `streampack.urltitle.similarityThreshold` | 0.3 | Jaccard similarity threshold; titles more similar than this to the URL are suppressed |
+| `streampack.urltitle.connectTimeoutSeconds` | 5 | HTTP connection timeout |
+| `streampack.urltitle.readTimeoutSeconds` | 10 | HTTP read timeout |

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/HtmlTitleFetcher.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/HtmlTitleFetcher.kt
@@ -2,25 +2,46 @@
 package com.enigmastation.streampack.core.service
 
 import org.jsoup.Jsoup
+import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-/** TitleFetcher that extracts titles from HTML, falling back to OpenGraph and Twitter meta tags */
+/**
+ * TitleFetcher that extracts titles from HTML. Prefers og:title (designed for link sharing) over
+ * the HTML title tag (often contains only site branding without JS rendering).
+ */
 @Component
 class HtmlTitleFetcher(private val pageFetcher: PageFetcher) : TitleFetcher {
+    private val logger = LoggerFactory.getLogger(HtmlTitleFetcher::class.java)
 
     override fun fetchTitle(url: String): String? {
-        val body = pageFetcher.fetch(url) ?: return null
+        val body = pageFetcher.fetch(url)
+        if (body == null) {
+            logger.debug("No body returned for {}", url)
+            return null
+        }
         val doc = Jsoup.parse(body)
-
-        val title = doc.title().takeIf { it.isNotBlank() }
-        if (title != null) return title
 
         val ogTitle =
             doc.select("meta[property=og:title]").attr("content").takeIf { it.isNotBlank() }
-        if (ogTitle != null) return ogTitle
+        if (ogTitle != null) {
+            logger.debug("Found og:title for {}: {}", url, ogTitle)
+            return ogTitle
+        }
 
         val twitterTitle =
             doc.select("meta[name=twitter:title]").attr("content").takeIf { it.isNotBlank() }
-        return twitterTitle
+        if (twitterTitle != null) {
+            logger.debug("Found twitter:title for {}: {}", url, twitterTitle)
+            return twitterTitle
+        }
+
+        val title = doc.title().takeIf { it.isNotBlank() }
+        if (title != null) {
+            logger.debug("Found <title> for {}: {}", url, title)
+            return title
+        }
+
+        logger.debug("No title found in any source for {}", url)
+        return null
     }
 }

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/HttpPageFetcher.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/HttpPageFetcher.kt
@@ -1,15 +1,17 @@
 /* Joseph B. Ottinger (C)2026 */
 package com.enigmastation.streampack.core.service
 
+import java.io.InputStream
 import java.net.URI
 import java.net.http.HttpClient
 import java.net.http.HttpRequest
 import java.net.http.HttpResponse
 import java.time.Duration
+import java.util.zip.GZIPInputStream
 import org.slf4j.LoggerFactory
 import org.springframework.stereotype.Component
 
-/** Default PageFetcher that retrieves page content over HTTP */
+/** Default PageFetcher that retrieves page content over HTTP, handling gzip responses */
 @Component
 class HttpPageFetcher : PageFetcher {
     private val logger = LoggerFactory.getLogger(HttpPageFetcher::class.java)
@@ -37,17 +39,42 @@ class HttpPageFetcher : PageFetcher {
                         "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
                     )
                     .header("Accept-Language", "en-US,en;q=0.5")
+                    .header("Accept-Encoding", "gzip")
                     .GET()
                     .build()
-            val response = client.send(request, HttpResponse.BodyHandlers.ofString())
-            if (response.statusCode() in 200..299) {
-                response.body()
-            } else {
-                logger.debug("HTTP {} fetching {}", response.statusCode(), url)
-                null
+            val response = client.send(request, HttpResponse.BodyHandlers.ofInputStream())
+            val finalUri = response.uri()
+
+            if (response.statusCode() !in 200..299) {
+                logger.warn(
+                    "HTTP {} fetching {} (final URI: {})",
+                    response.statusCode(),
+                    url,
+                    finalUri,
+                )
+                return null
             }
+
+            val encoding = response.headers().firstValue("Content-Encoding").orElse("")
+            val inputStream: InputStream =
+                if (encoding.equals("gzip", ignoreCase = true)) {
+                    GZIPInputStream(response.body())
+                } else {
+                    response.body()
+                }
+
+            val body = inputStream.bufferedReader(Charsets.UTF_8).use { it.readText() }
+            logger.debug(
+                "Fetched {} -> {} (status={}, encoding={}, body={} chars)",
+                url,
+                finalUri,
+                response.statusCode(),
+                encoding.ifEmpty { "none" },
+                body.length,
+            )
+            body
         } catch (e: Exception) {
-            logger.debug("Failed to fetch {}: {}", url, e.message)
+            logger.warn("Failed to fetch {}: {}", url, e.message)
             null
         }
     }

--- a/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/HtmlTitleFetcherTests.kt
+++ b/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/HtmlTitleFetcherTests.kt
@@ -39,12 +39,24 @@ class HtmlTitleFetcherTests {
     }
 
     @Test
-    fun `prefers title tag over og title`() {
+    fun `prefers og title over title tag`() {
         val html =
-            """<html><head><title>Real Title</title>
-            <meta property="og:title" content="OG Title">
+            """<html><head><title>Site Name</title>
+            <meta property="og:title" content="Actual Article Title">
             </head><body></body></html>"""
-        assertEquals("Real Title", fetcherWith(html).fetchTitle("http://example.com"))
+        assertEquals("Actual Article Title", fetcherWith(html).fetchTitle("http://example.com"))
+    }
+
+    @Test
+    fun `og title wins over useless title tag like YouTube`() {
+        val html =
+            """<html><head><title>- YouTube</title>
+            <meta property="og:title" content="Top 5 Hollywood DISASTERS of 2025">
+            </head><body></body></html>"""
+        assertEquals(
+            "Top 5 Hollywood DISASTERS of 2025",
+            fetcherWith(html).fetchTitle("http://example.com"),
+        )
     }
 
     @Test

--- a/operation-urltitle/src/main/kotlin/com/enigmastation/streampack/urltitle/config/UrlTitleProperties.kt
+++ b/operation-urltitle/src/main/kotlin/com/enigmastation/streampack/urltitle/config/UrlTitleProperties.kt
@@ -15,7 +15,7 @@ data class UrlTitleProperties(
             Protocol.MATTERMOST,
         ),
     val defaultIgnoredHosts: List<String> =
-        listOf("bpa.st", "dpaste.com", "pastebin.com", "pastebin.org"),
+        listOf("bpa.st", "dpaste.com", "pastebin.com", "pastebin.org", "twitter.com", "x.com"),
     val similarityThreshold: Double = 0.3,
     val connectTimeoutSeconds: Int = 5,
     val readTimeoutSeconds: Int = 10,

--- a/operation-urltitle/src/test/kotlin/com/enigmastation/streampack/urltitle/operation/LiveUrlTitleTests.kt
+++ b/operation-urltitle/src/test/kotlin/com/enigmastation/streampack/urltitle/operation/LiveUrlTitleTests.kt
@@ -1,0 +1,74 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.urltitle.operation
+
+import com.enigmastation.streampack.core.service.HtmlTitleFetcher
+import com.enigmastation.streampack.core.service.HttpPageFetcher
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty
+import org.slf4j.LoggerFactory
+
+/**
+ * Live integration tests that hit real URLs. Disabled by default. Run with:
+ * ```
+ * ./mvnw test -pl operation-urltitle -Dtest=LiveUrlTitleTests -Dlive.tests=true
+ * ```
+ */
+@EnabledIfSystemProperty(named = "live.tests", matches = "true")
+class LiveUrlTitleTests {
+    private val logger = LoggerFactory.getLogger(LiveUrlTitleTests::class.java)
+    private val pageFetcher = HttpPageFetcher()
+    private val titleFetcher = HtmlTitleFetcher(pageFetcher)
+
+    @Test
+    fun `fetch title from x_com - diagnostic only`() {
+        val url = "https://x.com/dev_maims/status/2022588131623501927"
+        logger.info("Fetching page body for {}", url)
+        val body = pageFetcher.fetch(url)
+        logger.info("Body returned: {} chars", body?.length ?: "null")
+        if (body != null) {
+            logger.info("First 500 chars: {}", body.take(500))
+            logMetaTags(body, url)
+        }
+
+        logger.info("Fetching title for {}", url)
+        val title = titleFetcher.fetchTitle(url)
+        logger.info("Title result: {}", title ?: "null")
+        // No assertions - x.com requires API access for reliable title extraction
+    }
+
+    @Test
+    fun `fetch title from youtube`() {
+        val url = "https://www.youtube.com/watch?v=jNDWnMfDnuw"
+        logger.info("Fetching page body for {}", url)
+        val body = pageFetcher.fetch(url)
+        logger.info("Body returned: {} chars", body?.length ?: "null")
+        if (body != null) {
+            logger.info("First 500 chars: {}", body.take(500))
+            logMetaTags(body, url)
+        }
+
+        logger.info("Fetching title for {}", url)
+        val title = titleFetcher.fetchTitle(url)
+        logger.info("Title result: {}", title ?: "null")
+        assertNotNull(title, "Expected a title from YouTube but got null")
+        assertTrue(title!!.isNotBlank(), "Title from YouTube should not be blank")
+    }
+
+    /** Dumps all meta tags from the HTML for diagnostic purposes */
+    private fun logMetaTags(body: String, url: String) {
+        val doc = org.jsoup.Jsoup.parse(body)
+        logger.info("--- <title> for {} ---", url)
+        logger.info("  {}", doc.title().ifBlank { "(empty)" })
+        logger.info("--- meta tags for {} ---", url)
+        for (meta in doc.select("meta[property], meta[name]")) {
+            val key = meta.attr("property").ifBlank { meta.attr("name") }
+            val content = meta.attr("content")
+            if (content.isNotBlank()) {
+                logger.info("  {} = {}", key, content)
+            }
+        }
+        logger.info("--- end meta tags ---")
+    }
+}

--- a/operation-urltitle/src/test/kotlin/com/enigmastation/streampack/urltitle/service/UrlTitleServiceTests.kt
+++ b/operation-urltitle/src/test/kotlin/com/enigmastation/streampack/urltitle/service/UrlTitleServiceTests.kt
@@ -74,12 +74,6 @@ class UrlTitleServiceTests {
     }
 
     @Test
-    fun `twitter and x_com are no longer ignored by default`() {
-        assertFalse(service.isIgnoredHost("https://twitter.com/someuser"))
-        assertFalse(service.isIgnoredHost("https://x.com/someuser/status/123"))
-    }
-
-    @Test
     fun `subdomain of ignored host is not ignored`() {
         assertFalse(service.isIgnoredHost("https://foo.pastebin.com/something"))
     }


### PR DESCRIPTION
Twitter support was considered and rejected; twitter reads need to go through the API now and they're /bin/zsh.005 a read. Without sponsorship, this feature isn't worth coding yet. Capitalism good, but this represents a literal investment I'm not willing to make yet.

Closes #28