### PR TITLE
Adding operation timeout

### DIFF
--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/Operation.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/Operation.kt
@@ -6,6 +6,7 @@ import com.enigmastation.streampack.core.model.OperationOutcome
 import com.enigmastation.streampack.core.model.OperationResult
 import com.enigmastation.streampack.core.model.RedactionRule
 import com.enigmastation.streampack.core.model.ThrottlePolicy
+import java.time.Duration
 import org.slf4j.Logger
 import org.slf4j.LoggerFactory
 import org.springframework.messaging.Message
@@ -58,6 +59,14 @@ interface Operation {
      */
     val redactionRules: List<RedactionRule>
         get() = emptyList()
+
+    /**
+     * Maximum time this operation may spend in [execute] before being interrupted. When an
+     * operation exceeds its timeout, the executing thread is interrupted, the result is discarded,
+     * and the chain continues to the next operation.
+     */
+    val timeout: Duration
+        get() = Duration.ofSeconds(30)
 
     /**
      * Optional rate limit for this operation. When set, OperationService checks a token bucket

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/OperationService.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/OperationService.kt
@@ -6,8 +6,12 @@ import com.enigmastation.streampack.core.integration.EventGateway
 import com.enigmastation.streampack.core.model.Declined
 import com.enigmastation.streampack.core.model.FanOut
 import com.enigmastation.streampack.core.model.LoggingRequest
+import com.enigmastation.streampack.core.model.OperationOutcome
 import com.enigmastation.streampack.core.model.OperationResult
 import com.enigmastation.streampack.core.model.Provenance
+import java.util.concurrent.Executors
+import java.util.concurrent.ScheduledExecutorService
+import java.util.concurrent.TimeUnit
 import org.slf4j.LoggerFactory
 import org.springframework.beans.factory.annotation.Qualifier
 import org.springframework.context.annotation.Lazy
@@ -39,6 +43,8 @@ class OperationService(
 ) {
     private val logger = LoggerFactory.getLogger(OperationService::class.java)
     private val sortedOperations = operations.sortedBy { it.priority }
+    private val watchdogScheduler: ScheduledExecutorService =
+        Executors.newSingleThreadScheduledExecutor(Thread.ofVirtual().factory())
 
     /**
      * Checks whether any non-addressed operation is interested in this message.
@@ -99,7 +105,14 @@ class OperationService(
                     op::class.simpleName,
                     message.headers.id,
                 )
-                val result = op.execute(message)
+                val result = executeWithTimeout(op, message)
+                if (result == null) {
+                    logger.debug(
+                        "Operation {} returned null, continuing chain",
+                        op::class.simpleName,
+                    )
+                    continue
+                }
                 if (result is Declined) {
                     logger.info(
                         "Operation {} declined message {}: {}",
@@ -128,7 +141,6 @@ class OperationService(
                     }
                     return result
                 }
-                logger.debug("Operation {} returned null, continuing chain", op::class.simpleName)
             }
         }
         logger.debug("No operation handled message {}", message.headers.id)
@@ -190,6 +202,42 @@ class OperationService(
         val provenanceUri = provenance?.encode() ?: "unknown"
         val key = "${op::class.simpleName}:$provenanceUri"
         return throttleService.tryAcquire(key, policy)
+    }
+
+    /**
+     * Executes an operation on the current thread with a scheduled watchdog interrupt. Keeping
+     * execution on the caller's thread preserves transaction context and ThreadLocal state. On
+     * timeout the watchdog interrupts the operation thread; blocking I/O and Thread.sleep on
+     * virtual threads respond to interruption.
+     */
+    private fun executeWithTimeout(op: Operation, message: Message<*>): OperationOutcome? {
+        val caller = Thread.currentThread()
+        val watchdog =
+            watchdogScheduler.schedule(
+                { caller.interrupt() },
+                op.timeout.toMillis(),
+                TimeUnit.MILLISECONDS,
+            )
+        return try {
+            val result = op.execute(message)
+            watchdog.cancel(false)
+            Thread.interrupted() // clear any interrupt that raced with completion
+            result
+        } catch (e: InterruptedException) {
+            watchdog.cancel(false)
+            Thread.interrupted()
+            logger.warn(
+                "Operation {} timed out after {} for message {}",
+                op::class.simpleName,
+                op.timeout,
+                message.headers.id,
+            )
+            null
+        } catch (e: Exception) {
+            watchdog.cancel(false)
+            Thread.interrupted()
+            throw e
+        }
     }
 
     /** Dispatches each child message with an incremented hop count */

--- a/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/OperationTimeoutTests.kt
+++ b/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/OperationTimeoutTests.kt
@@ -1,0 +1,100 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.core.service
+
+import com.enigmastation.streampack.core.TestChannelConfiguration
+import com.enigmastation.streampack.core.integration.EventGateway
+import com.enigmastation.streampack.core.model.OperationOutcome
+import com.enigmastation.streampack.core.model.OperationResult
+import com.enigmastation.streampack.core.model.Protocol
+import com.enigmastation.streampack.core.model.Provenance
+import java.time.Duration
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Import
+import org.springframework.messaging.Message
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+@Import(TestChannelConfiguration::class)
+class OperationTimeoutTests {
+
+    @TestConfiguration
+    class TestOps {
+
+        /** Operation that sleeps longer than its timeout allows */
+        @Bean
+        fun slowOperation() =
+            object : Operation {
+                override val priority = 10
+                override val timeout: Duration = Duration.ofSeconds(2)
+
+                override fun canHandle(message: Message<*>): Boolean =
+                    (message.payload as? String) == "slow"
+
+                override fun execute(message: Message<*>): OperationOutcome {
+                    Thread.sleep(5_000)
+                    return OperationResult.Success("should not reach this")
+                }
+            }
+
+        /** Fallback operation at lower priority that proves the chain continues after timeout */
+        @Bean
+        fun fallbackOperation() =
+            object : Operation {
+                override val priority = 50
+
+                override fun canHandle(message: Message<*>): Boolean =
+                    (message.payload as? String) == "slow"
+
+                override fun execute(message: Message<*>): OperationOutcome =
+                    OperationResult.Success("fallback handled it")
+            }
+
+        /** Fast operation to verify normal operations are unaffected by timeout machinery */
+        @Bean
+        fun fastOperation() =
+            object : Operation {
+                override val priority = 10
+
+                override fun canHandle(message: Message<*>): Boolean =
+                    (message.payload as? String) == "fast"
+
+                override fun execute(message: Message<*>): OperationOutcome =
+                    OperationResult.Success("fast response")
+            }
+    }
+
+    @Autowired lateinit var eventGateway: EventGateway
+
+    private fun buildMessage(payload: String): Message<String> {
+        val provenance = Provenance(protocol = Protocol.CONSOLE, serviceId = "", replyTo = "local")
+        return MessageBuilder.withPayload(payload).setHeader(Provenance.HEADER, provenance).build()
+    }
+
+    @Test
+    fun `timed out operation is skipped and chain continues to fallback`() {
+        val start = System.currentTimeMillis()
+        val result = eventGateway.process(buildMessage("slow"))
+        val elapsed = System.currentTimeMillis() - start
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val payload = (result as OperationResult.Success).payload as String
+        assertTrue(payload == "fallback handled it") { "Expected fallback, got: $payload" }
+        assertTrue(elapsed < 4_000) { "Should complete in ~2s timeout, took ${elapsed}ms" }
+    }
+
+    @Test
+    fun `fast operation completes normally`() {
+        val result = eventGateway.process(buildMessage("fast"))
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val payload = (result as OperationResult.Success).payload as String
+        assertTrue(payload == "fast response") { "Expected fast response, got: $payload" }
+    }
+}


### PR DESCRIPTION
This should help address the potential of poorly-behaved operations. It's not a PERFECT solution, I think, but a perfect generalized solution is likely to be a lot more of a problem than a *good* generalized solution.

A perfect generalized solution is going to have dispatch channels for every operation, probably, and require a cascade through a lot of channels such that TX boundaries are met, and that's a lot for the project as it stands. When it's handling millions of dollars' worth of operations, maybe it'll be worth revisiting but not now.

Fixes #113