### PR TITLE
Updating to make OIDC configuration a runtime profile

### DIFF
--- a/app/src/main/resources/application-oidc.yml
+++ b/app/src/main/resources/application-oidc.yml
@@ -1,0 +1,12 @@
+spring:
+  security:
+    oauth2:
+      client:
+        registration:
+          google:
+            client-id: ${GOOGLE_CLIENT_ID}
+            client-secret: ${GOOGLE_CLIENT_SECRET}
+            scope: openid,email,profile
+          github:
+            client-id: ${GITHUB_CLIENT_ID}
+            client-secret: ${GITHUB_CLIENT_SECRET}

--- a/app/src/main/resources/application.yml
+++ b/app/src/main/resources/application.yml
@@ -27,18 +27,6 @@ spring:
   application:
     name: nevet
     version: 3.0
-  security:
-    oauth2:
-      client:
-        registration:
-          google:
-            client-id: ${GOOGLE_CLIENT_ID:}
-            client-secret: ${GOOGLE_CLIENT_SECRET:}
-            scope: openid,email,profile
-          github:
-            client-id: ${GITHUB_CLIENT_ID:}
-            client-secret: ${GITHUB_CLIENT_SECRET:}
-
 streampack:
   base-url: ${BASE_URL:http://localhost:8080}
   jwt:

--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -55,7 +55,9 @@ OTP verification implies email verification, so no separate email verification s
 ## OIDC Flow
 
 OIDC uses Spring Security's OAuth2 Client with Google and GitHub as providers.
-See [Deployment Guide](deployment.md#oidc-setup) for configuration instructions.
+OIDC is activated by enabling the `oidc` Spring profile.
+Without the profile, the app runs OTP-only and no OAuth2 endpoints are registered.
+See [Deployment Guide](deployment.md#oidc-setup) for activation instructions and provider setup.
 
 ### How it works
 
@@ -72,11 +74,6 @@ See [Deployment Guide](deployment.md#oidc-setup) for configuration instructions.
 - **GitHub**: Returns email via the `email` attribute on the OAuth2 user profile
 
 Both are handled transparently by the success handler.
-
-### Conditional activation
-
-OIDC is only enabled when OAuth2 client registrations are configured.
-If `GOOGLE_CLIENT_ID` and `GITHUB_CLIENT_ID` are both empty, OIDC endpoints are not registered and the app runs OTP-only.
 
 ## JWT Tokens
 

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -312,9 +312,55 @@ curl -s -o /dev/null -w "%{http_code}" https://bytecode.news/api/v3/api-docs   #
 
 Nevet supports "Sign in with Google" and "Sign in with GitHub" via OIDC / OAuth2.
 Both are optional and independent - configure one, both, or neither.
-When neither is configured, the app works with OTP-only authentication.
+When OIDC is not enabled, the app works with OTP-only authentication.
 
-### Google
+OIDC is gated behind the `oidc` Spring profile.
+Without the profile active, the OAuth2 client auto-configuration is not loaded and no OIDC endpoints are registered.
+The app starts and runs normally with OTP as the sole authentication method.
+
+### Activating the OIDC Profile
+
+There are several ways to activate the profile, depending on how you run the application.
+
+**From the command line** (local development or manual launch):
+
+```bash
+java -jar app/target/app-1.0.jar --spring.profiles.active=oidc
+```
+
+Multiple profiles can be comma-separated:
+
+```bash
+java -jar app/target/app-1.0.jar --spring.profiles.active=oidc,someotherprofile
+```
+
+**Via environment variable** (Docker, systemd, CI):
+
+```bash
+export SPRING_PROFILES_ACTIVE=oidc
+java -jar app/target/app-1.0.jar
+```
+
+**In the `.env` file**:
+
+```
+SPRING_PROFILES_ACTIVE=oidc
+```
+
+**In a systemd unit** (production):
+
+```ini
+[Service]
+Environment=SPRING_PROFILES_ACTIVE=oidc
+ExecStart=/opt/java/jdk-25/bin/java -jar app/target/app-1.0.jar
+```
+
+### Provider Setup
+
+When the `oidc` profile is active, the following environment variables are required.
+You can configure one provider or both.
+
+#### Google
 
 1. Go to [Google Cloud Console](https://console.cloud.google.com/) and create a project (no billing required)
 2. Navigate to **APIs & Services > OAuth consent screen**, choose **External**, add scopes: `openid`, `email`, `profile`
@@ -324,14 +370,14 @@ When neither is configured, the app works with OTP-only authentication.
    - For local dev: `http://localhost:8080/login/oauth2/code/google`
 6. Copy the **Client ID** and **Client Secret**
 
-Configure:
+Add to your `.env`:
 
-```bash
-export GOOGLE_CLIENT_ID="your-client-id.apps.googleusercontent.com"
-export GOOGLE_CLIENT_SECRET="your-client-secret"
+```
+GOOGLE_CLIENT_ID=your-client-id.apps.googleusercontent.com
+GOOGLE_CLIENT_SECRET=your-client-secret
 ```
 
-### GitHub
+#### GitHub
 
 1. Go to [GitHub Developer Settings](https://github.com/settings/developers), click **OAuth Apps > New OAuth App**
 2. Homepage URL: `https://your-domain.com`
@@ -339,11 +385,11 @@ export GOOGLE_CLIENT_SECRET="your-client-secret"
    - For local dev: `http://localhost:8080/login/oauth2/code/github`
 4. Copy the **Client ID** and generate a **Client Secret**
 
-Configure:
+Add to your `.env`:
 
-```bash
-export GITHUB_CLIENT_ID="your-client-id"
-export GITHUB_CLIENT_SECRET="your-client-secret"
+```
+GITHUB_CLIENT_ID=your-client-id
+GITHUB_CLIENT_SECRET=your-client-secret
 ```
 
 ### Split-Domain Deployment
@@ -562,6 +608,7 @@ After=network.target postgresql.service
 Type=simple
 User=nevet
 WorkingDirectory=/opt/nevet
+# Add SPRING_PROFILES_ACTIVE=oidc to enable OIDC authentication (see OIDC Setup)
 ExecStart=/opt/java/jdk-25/bin/java -jar app/target/app-1.0.jar
 Restart=on-failure
 RestartSec=10
@@ -663,10 +710,10 @@ Rotate: `find /backups -name "nevet-*.dump" -mtime +30 -delete`.
 | `ANTHROPIC_API_KEY` | (empty) | Anthropic API key |
 | `OPENWEATHERMAP_API_KEY` | | OpenWeatherMap API key |
 | `KARMA_IMMUNE_SUBJECTS` | `nevet` | Comma-separated karma-immune names |
-| `GOOGLE_CLIENT_ID` | | Google OAuth2 client ID |
-| `GOOGLE_CLIENT_SECRET` | | Google OAuth2 client secret |
-| `GITHUB_CLIENT_ID` | | GitHub OAuth2 client ID |
-| `GITHUB_CLIENT_SECRET` | | GitHub OAuth2 client secret |
+| `GOOGLE_CLIENT_ID` | | Google OAuth2 client ID (requires `oidc` profile) |
+| `GOOGLE_CLIENT_SECRET` | | Google OAuth2 client secret (requires `oidc` profile) |
+| `GITHUB_CLIENT_ID` | | GitHub OAuth2 client ID (requires `oidc` profile) |
+| `GITHUB_CLIENT_SECRET` | | GitHub OAuth2 client secret (requires `oidc` profile) |
 | `RSS_POLL_INTERVAL` | `PT60M` | RSS polling interval (ISO-8601) |
 | `GITHUB_POLL_INTERVAL` | `PT60M` | GitHub polling interval (ISO-8601) |
 | `API_URL` | `http://localhost:8080` | Backend URL for frontend rewrites |


### PR DESCRIPTION
To use OIDC, configure the OIDC deployment values, and run with SPRING_ACTIVE_PROFILES=oidc in the environment.

Fixes #127