### PR TITLE
Adding autodeop feature for IRC services

### DIFF
--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -463,6 +463,21 @@ The only application properties are the on/off switch and the default signal cha
 
 See [User Guide](user-guide.md#irc-super-admin) for the full set of admin commands.
 
+### Auto-Deop
+
+By default, the bot automatically removes channel operator status (`+o`) from itself when opped.
+A bot should not hold ops - it is unnecessary privilege and a potential abuse vector.
+
+The behavior is per-channel and controlled via `irc allow-ops`:
+
+```
+irc allow-ops libera #java true     allow the bot to stay opped
+irc allow-ops libera #java false    restore default auto-deop behavior
+```
+
+The default is `false` (auto-deop enabled).
+The setting is stored via `ProvenanceStateService` and persists across restarts.
+
 ---
 
 ## Slack Adapter Setup

--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -640,6 +640,7 @@ See [Deployment Guide](deployment.md#irc-adapter-setup) for initial setup.
 | `irc automute <network> <#channel> <true\|false>` | Start muted |
 | `irc visible <network> <#channel> <true\|false>` | Show in UI |
 | `irc logged <network> <#channel> <true\|false>` | Log messages to database |
+| `irc allow-ops <network> <#channel> <true\|false>` | Allow bot to hold ops (default: false, auto-deops) |
 | `irc mute <network> <#channel>` | Mute channel now (session only) |
 | `irc unmute <network> <#channel>` | Unmute channel now (session only) |
 

--- a/operation-hangman/src/main/kotlin/com/enigmastation/streampack/hangman/operation/HangmanOperation.kt
+++ b/operation-hangman/src/main/kotlin/com/enigmastation/streampack/hangman/operation/HangmanOperation.kt
@@ -227,7 +227,7 @@ class HangmanOperation(
         val ZERO_GUESS_REACTIONS =
             listOf(
                 "Wait, what... how? That's amazing! ... or suspicious.",
-                "Wait, you got it without guessing a single letter? I'm not saying you cheated, but if I had eyebrows...",
+                "Wait, you nailed it without guessing a single letter? I'm not saying you cheated, but if I had eyebrows...",
                 "Zero letters guessed and you nailed it? That's either genius or espionage.",
                 "Impressive! Or suspicious. Let's go with impressively suspicious.",
                 "You solved it cold? I'll just be over here checking the server logs.",

--- a/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/operation/IrcAdminOperation.kt
+++ b/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/operation/IrcAdminOperation.kt
@@ -50,6 +50,7 @@ class IrcAdminOperation(private val ircService: IrcService) :
             "automute" -> handleAutomute(tokens.drop(1))
             "visible" -> handleVisible(tokens.drop(1))
             "logged" -> handleLogged(tokens.drop(1))
+            "allow-ops" -> handleAllowOps(tokens.drop(1))
             "signal" -> handleSignal(tokens.drop(1))
             "status" -> handleStatus(tokens.drop(1))
             else ->
@@ -189,6 +190,19 @@ class IrcAdminOperation(private val ircService: IrcService) :
         else OperationResult.Success(result)
     }
 
+    private fun handleAllowOps(args: List<String>): OperationResult {
+        if (args.size < 3) {
+            return OperationResult.Error("Usage: irc allow-ops <network> <#channel> <true|false>")
+        }
+        val enabled =
+            args[2].toBooleanStrictOrNull()
+                ?: return OperationResult.Error("Invalid boolean: '${args[2]}'")
+        val result = ircService.setAllowOps(args[0], args[1], enabled)
+        return if (result.startsWith("Error:"))
+            OperationResult.Error(result.removePrefix("Error: "))
+        else OperationResult.Success(result)
+    }
+
     private fun handleSignal(args: List<String>): OperationResult {
         if (args.isEmpty()) {
             return OperationResult.Error(
@@ -222,6 +236,7 @@ class IrcAdminOperation(private val ircService: IrcService) :
         |  irc automute <network> <#channel> <true|false>
         |  irc visible <network> <#channel> <true|false>
         |  irc logged <network> <#channel> <true|false>
+        |  irc allow-ops <network> <#channel> <true|false>
         |  irc signal <name> [character]
         |  irc status [network]
         """

--- a/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcAdapter.kt
+++ b/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcAdapter.kt
@@ -7,14 +7,17 @@ import com.enigmastation.streampack.core.model.Protocol
 import com.enigmastation.streampack.core.model.Provenance
 import com.enigmastation.streampack.core.service.ChannelControlService
 import com.enigmastation.streampack.core.service.ProtocolAdapter
+import com.enigmastation.streampack.core.service.ProvenanceStateService
 import com.enigmastation.streampack.core.service.UserResolutionService
 import com.enigmastation.streampack.irc.repository.IrcChannelRepository
 import com.enigmastation.streampack.irc.repository.IrcNetworkRepository
 import net.engio.mbassy.listener.Handler
 import org.kitteh.irc.client.library.Client
+import org.kitteh.irc.client.library.element.mode.ModeStatus
 import org.kitteh.irc.client.library.event.channel.ChannelCtcpEvent
 import org.kitteh.irc.client.library.event.channel.ChannelJoinEvent
 import org.kitteh.irc.client.library.event.channel.ChannelMessageEvent
+import org.kitteh.irc.client.library.event.channel.ChannelModeEvent
 import org.kitteh.irc.client.library.event.channel.ChannelPartEvent
 import org.kitteh.irc.client.library.event.channel.ChannelTopicEvent
 import org.kitteh.irc.client.library.event.channel.RequestedChannelJoinCompleteEvent
@@ -34,6 +37,7 @@ class IrcAdapter(
     private val eventGateway: EventGateway,
     private val userResolutionService: UserResolutionService,
     private val channelControlService: ChannelControlService,
+    private val stateService: ProvenanceStateService,
     private val networkRepository: IrcNetworkRepository,
     private val channelRepository: IrcChannelRepository,
     private val client: Client,
@@ -95,6 +99,36 @@ class IrcAdapter(
             if (options?.autojoin == true) {
                 logger.info("Auto-joining {} on {}", channel.name, networkName)
                 client.addChannel(channel.name)
+            }
+        }
+    }
+
+    /** Auto-deops the bot when it receives +o, unless allow-ops is enabled for the channel */
+    @Handler
+    fun onChannelMode(event: ChannelModeEvent) {
+        val opChanges = event.statusList.getByMode('o')
+        for (change in opChanges) {
+            if (
+                change.action == ModeStatus.Action.ADD &&
+                    change.parameter.orElse(null) == client.nick
+            ) {
+                val channelName = event.channel.name
+                val provenanceUri =
+                    Provenance(
+                            protocol = Protocol.IRC,
+                            serviceId = networkName,
+                            replyTo = channelName,
+                        )
+                        .encode()
+                val state = stateService.getState(provenanceUri, ALLOW_OPS_KEY)
+                if (state == null) {
+                    stateService.setState(provenanceUri, ALLOW_OPS_KEY, mapOf("enabled" to false))
+                }
+                val allowOps = state?.get("enabled") as? Boolean ?: false
+                if (!allowOps) {
+                    client.sendRawLine("MODE $channelName -o ${client.nick}")
+                    logger.info("Auto-deopping in {} on {}", channelName, networkName)
+                }
             }
         }
     }
@@ -269,6 +303,7 @@ class IrcAdapter(
     }
 
     companion object {
+        const val ALLOW_OPS_KEY = "irc-allow-ops"
         private const val MAX_IRC_MESSAGE_LENGTH = 400
         private const val TRUNCATION_SUFFIX = " [...more]"
 

--- a/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcConnectionManager.kt
+++ b/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcConnectionManager.kt
@@ -3,6 +3,7 @@ package com.enigmastation.streampack.irc.service
 
 import com.enigmastation.streampack.core.integration.EventGateway
 import com.enigmastation.streampack.core.service.ChannelControlService
+import com.enigmastation.streampack.core.service.ProvenanceStateService
 import com.enigmastation.streampack.core.service.UserResolutionService
 import com.enigmastation.streampack.irc.config.IrcProperties
 import com.enigmastation.streampack.irc.entity.IrcNetwork
@@ -27,6 +28,7 @@ class IrcConnectionManager(
     private val eventGateway: EventGateway,
     private val userResolutionService: UserResolutionService,
     private val channelControlService: ChannelControlService,
+    private val provenanceStateService: ProvenanceStateService,
     private val ircProperties: IrcProperties,
     private val networkRepository: IrcNetworkRepository,
     private val channelRepository: IrcChannelRepository,
@@ -85,6 +87,7 @@ class IrcConnectionManager(
                 eventGateway = eventGateway,
                 userResolutionService = userResolutionService,
                 channelControlService = channelControlService,
+                stateService = provenanceStateService,
                 networkRepository = networkRepository,
                 channelRepository = channelRepository,
                 client = client,

--- a/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcService.kt
+++ b/service-irc/src/main/kotlin/com/enigmastation/streampack/irc/service/IrcService.kt
@@ -2,6 +2,7 @@
 package com.enigmastation.streampack.irc.service
 
 import com.enigmastation.streampack.core.service.ChannelControlService
+import com.enigmastation.streampack.core.service.ProvenanceStateService
 import com.enigmastation.streampack.irc.entity.IrcChannel
 import com.enigmastation.streampack.irc.entity.IrcNetwork
 import com.enigmastation.streampack.irc.repository.IrcChannelRepository
@@ -20,6 +21,7 @@ class IrcService(
     private val networkRepository: IrcNetworkRepository,
     private val channelRepository: IrcChannelRepository,
     private val channelControlService: ChannelControlService,
+    private val provenanceStateService: ProvenanceStateService,
     private val connectionManager: ObjectProvider<IrcConnectionManager>,
 ) {
     private val logger = LoggerFactory.getLogger(IrcService::class.java)
@@ -169,6 +171,15 @@ class IrcService(
                 ?: return channelNotFoundError(networkName, channelName)
         channelControlService.setFlag(uri, "logged", logged)
         return "Channel '$channelName' on '$networkName' logged set to $logged"
+    }
+
+    /** Configures whether the bot is allowed to hold ops in a channel */
+    fun setAllowOps(networkName: String, channelName: String, enabled: Boolean): String {
+        val uri =
+            resolveChannelUri(networkName, channelName)
+                ?: return channelNotFoundError(networkName, channelName)
+        provenanceStateService.setState(uri, IrcAdapter.ALLOW_OPS_KEY, mapOf("enabled" to enabled))
+        return "Channel '$channelName' on '$networkName' allow-ops set to $enabled"
     }
 
     /** Soft-deletes a network and its channels, disconnecting the runtime adapter if active */


### PR DESCRIPTION
If nevet gets +o for any reason, it's set to remove ops for itself, although this is controllable per-channel.