### PR TITLE
Cleaning up some test coverage and fixing one factoid runtime concern

### DIFF
--- a/lib-blog/src/test/kotlin/com/enigmastation/streampack/blog/operation/FindContentOperationTests.kt
+++ b/lib-blog/src/test/kotlin/com/enigmastation/streampack/blog/operation/FindContentOperationTests.kt
@@ -56,6 +56,7 @@ class FindContentOperationTests {
 
     private lateinit var author: User
     private lateinit var admin: User
+    private lateinit var superAdmin: User
     private lateinit var otherUser: User
     private lateinit var publishedPost: Post
     private lateinit var draftPost: Post
@@ -84,6 +85,16 @@ class FindContentOperationTests {
                     displayName = "Admin User",
                     emailVerified = true,
                     role = Role.ADMIN,
+                )
+            )
+        superAdmin =
+            userRepository.save(
+                User(
+                    username = "superadmin",
+                    email = "superadmin@test.com",
+                    displayName = "Super Admin",
+                    emailVerified = true,
+                    role = Role.SUPER_ADMIN,
                 )
             )
         otherUser =
@@ -249,6 +260,15 @@ class FindContentOperationTests {
     }
 
     @Test
+    fun `FindById for draft by non-author returns error`() {
+        val result =
+            eventGateway.process(findMessage(FindContentRequest.FindById(draftPost.id), otherUser))
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("Post not found", (result as OperationResult.Error).message)
+    }
+
+    @Test
     fun `FindPublished returns only published posts`() {
         val result = eventGateway.process(findMessage(FindContentRequest.FindPublished()))
 
@@ -312,6 +332,29 @@ class FindContentOperationTests {
 
         assertInstanceOf(OperationResult.Error::class.java, result)
         assertEquals("Post not found", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `anonymous user cannot see scheduled post via FindBySlug`() {
+        val result =
+            eventGateway.process(
+                findMessage(FindContentRequest.FindBySlug("2026/02/scheduled-post"), null)
+            )
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("Post not found", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `author can see scheduled post via FindBySlug`() {
+        val result =
+            eventGateway.process(
+                findMessage(FindContentRequest.FindBySlug("2026/02/scheduled-post"), author)
+            )
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val detail = (result as OperationResult.Success).payload as ContentDetail
+        assertEquals("Scheduled Post", detail.title)
     }
 
     @Test
@@ -486,6 +529,18 @@ class FindContentOperationTests {
     }
 
     @Test
+    fun `super admin receives markdownSource for any post`() {
+        val result =
+            eventGateway.process(
+                findMessage(FindContentRequest.FindBySlug("2026/02/published-post"), superAdmin)
+            )
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val detail = (result as OperationResult.Success).payload as ContentDetail
+        assertEquals("# Published", detail.markdownSource)
+    }
+
+    @Test
     fun `FindById as author includes markdownSource`() {
         val result =
             eventGateway.process(findMessage(FindContentRequest.FindById(publishedPost.id), author))
@@ -599,6 +654,81 @@ class FindContentOperationTests {
 
         assertInstanceOf(OperationResult.Error::class.java, result)
         assertEquals("Page not found", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `FindBySlug uses requested path when canonical slug missing`() {
+        val now = Instant.now()
+        val post =
+            postRepository.save(
+                Post(
+                    title = "Alias Only Post",
+                    markdownSource = "# Alias",
+                    renderedHtml = "<h1>Alias</h1>",
+                    excerpt = "alias only",
+                    status = PostStatus.APPROVED,
+                    publishedAt = now.minus(10, ChronoUnit.MINUTES),
+                    author = author,
+                )
+            )
+        slugRepository.save(Slug(path = "2026/03/alias-only", post = post, canonical = false))
+
+        val result =
+            eventGateway.process(findMessage(FindContentRequest.FindBySlug("2026/03/alias-only")))
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val detail = (result as OperationResult.Success).payload as ContentDetail
+        assertEquals("2026/03/alias-only", detail.slug)
+    }
+
+    @Test
+    fun `FindById uses empty slug when canonical slug missing`() {
+        val now = Instant.now()
+        val post =
+            postRepository.save(
+                Post(
+                    title = "Id Only Post",
+                    markdownSource = "# ID",
+                    renderedHtml = "<h1>ID</h1>",
+                    excerpt = "id only",
+                    status = PostStatus.APPROVED,
+                    publishedAt = now.minus(10, ChronoUnit.MINUTES),
+                    author = author,
+                )
+            )
+        slugRepository.save(Slug(path = "2026/03/id-only", post = post, canonical = false))
+
+        val result = eventGateway.process(findMessage(FindContentRequest.FindById(post.id)))
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val detail = (result as OperationResult.Success).payload as ContentDetail
+        assertEquals("", detail.slug)
+    }
+
+    @Test
+    fun `FindPage uses requested slug when canonical slug missing`() {
+        val pagesCategory = categoryRepository.findByName("_pages")!!
+        val now = Instant.now()
+        val page =
+            postRepository.save(
+                Post(
+                    title = "Alias Page",
+                    markdownSource = "# Alias Page",
+                    renderedHtml = "<h1>Alias Page</h1>",
+                    excerpt = "alias page",
+                    status = PostStatus.APPROVED,
+                    publishedAt = now.minus(10, ChronoUnit.MINUTES),
+                    author = admin,
+                )
+            )
+        slugRepository.save(Slug(path = "alias-page", post = page, canonical = false))
+        postCategoryRepository.save(PostCategory(post = page, category = pagesCategory))
+
+        val result = eventGateway.process(findMessage(FindContentRequest.FindPage("alias-page")))
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val detail = (result as OperationResult.Success).payload as ContentDetail
+        assertEquals("alias-page", detail.slug)
     }
 
     @Test

--- a/lib-core/src/test/kotlin/com/enigmastation/streampack/core/operation/LinkProtocolOperationTests.kt
+++ b/lib-core/src/test/kotlin/com/enigmastation/streampack/core/operation/LinkProtocolOperationTests.kt
@@ -10,6 +10,9 @@ import com.enigmastation.streampack.core.model.Provenance
 import com.enigmastation.streampack.core.model.Role
 import com.enigmastation.streampack.core.model.UserPrincipal
 import com.enigmastation.streampack.core.repository.ServiceBindingRepository
+import com.enigmastation.streampack.core.service.IdentityDescription
+import com.enigmastation.streampack.core.service.IdentityProvider
+import com.enigmastation.streampack.core.service.IdentityResolution
 import com.enigmastation.streampack.core.service.UserRegistrationService
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertInstanceOf
@@ -18,6 +21,8 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.test.context.TestConfiguration
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Import
 import org.springframework.messaging.support.MessageBuilder
 import org.springframework.transaction.annotation.Transactional
@@ -25,8 +30,39 @@ import org.springframework.transaction.annotation.Transactional
 /** Integration tests for protocol identity linking via LinkProtocolOperation */
 @SpringBootTest
 @Transactional
-@Import(TestChannelConfiguration::class)
+@Import(TestChannelConfiguration::class, LinkProtocolOperationTests.TestIdentityProviders::class)
 class LinkProtocolOperationTests {
+
+    @TestConfiguration
+    class TestIdentityProviders {
+        @Bean
+        fun testSlackIdentityProvider() =
+            object : IdentityProvider {
+                override val protocol: Protocol = Protocol.SLACK
+
+                override fun resolveIdentity(
+                    serviceId: String,
+                    externalIdentifier: String,
+                ): IdentityResolution {
+                    return if (serviceId == "invalid-workspace") {
+                        IdentityResolution.Invalid("Invalid Slack workspace")
+                    } else {
+                        IdentityResolution.Valid(
+                            serviceId = serviceId,
+                            externalIdentifier = externalIdentifier.lowercase(),
+                        )
+                    }
+                }
+
+                override fun describeIdentity(): IdentityDescription =
+                    IdentityDescription(
+                        protocol = Protocol.SLACK,
+                        serviceIdLabel = "workspace",
+                        externalIdLabel = "user ID",
+                        availableServices = listOf("test-workspace"),
+                    )
+            }
+    }
 
     @Autowired lateinit var eventGateway: EventGateway
     @Autowired lateinit var userRegistrationService: UserRegistrationService
@@ -280,5 +316,49 @@ class LinkProtocolOperationTests {
 
         assertInstanceOf(OperationResult.Error::class.java, result)
         assertEquals("User not found", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `provider validation failure returns provider reason`() {
+        val request =
+            LinkProtocolRequest(
+                username = "regularuser",
+                protocol = Protocol.SLACK,
+                serviceId = "invalid-workspace",
+                externalIdentifier = "SomeUser",
+            )
+        val result = eventGateway.process(linkProtocolMessage(request, superAdmin))
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("Invalid Slack workspace", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `message without provenance returns no provenance error`() {
+        val request =
+            LinkProtocolRequest(
+                username = "regularuser",
+                protocol = Protocol.IRC,
+                serviceId = "ircservice",
+                externalIdentifier = "regularuser_irc",
+            )
+        val message = MessageBuilder.withPayload(request).build()
+        val result = eventGateway.process(message)
+
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("No provenance", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `capitalized link command prefix is accepted`() {
+        val result =
+            eventGateway.process(
+                textMessage("Link user regularuser irc ircservice regularuser_caps", superAdmin)
+            )
+
+        assertInstanceOf(OperationResult.Success::class.java, result)
+        val binding =
+            serviceBindingRepository.resolve(Protocol.IRC, "ircservice", "regularuser_caps")
+        assertNotNull(binding)
     }
 }

--- a/lib-core/src/test/kotlin/com/enigmastation/streampack/core/operation/OperationConfigAdminTests.kt
+++ b/lib-core/src/test/kotlin/com/enigmastation/streampack/core/operation/OperationConfigAdminTests.kt
@@ -180,6 +180,40 @@ class OperationConfigAdminTests {
         assertEquals("50", config!!.config["maxItems"])
     }
 
+    @Test
+    fun `operation unknown subcommand returns error`() {
+        val result = eventGateway.process(buildMessage("operation explode", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertTrue(
+            (result as OperationResult.Error).message.contains("Unknown operation subcommand")
+        )
+    }
+
+    @Test
+    fun `operation enable without group returns usage error`() {
+        val result = eventGateway.process(buildMessage("operation enable", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("Usage: operation enable <group>", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `operation disable without group returns usage error`() {
+        val result = eventGateway.process(buildMessage("operation disable", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals("Usage: operation disable <group>", (result as OperationResult.Error).message)
+    }
+
+    @Test
+    fun `operation set without enough args returns usage error`() {
+        val result =
+            eventGateway.process(buildMessage("operation set test-admin-op onlyKey", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals(
+            "Usage: operation set <group> <key> <value>",
+            (result as OperationResult.Error).message,
+        )
+    }
+
     // -- ChannelConfigOperation tests --
 
     @Test
@@ -229,5 +263,58 @@ class OperationConfigAdminTests {
         assertInstanceOf(OperationResult.Success::class.java, result)
         val output = (result as OperationResult.Success).payload.toString()
         assertTrue(output.contains("test-admin-op"))
+    }
+
+    @Test
+    fun `channel unknown subcommand returns error`() {
+        val result = eventGateway.process(buildMessage("channel kaboom", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertTrue((result as OperationResult.Error).message.contains("Unknown channel subcommand"))
+    }
+
+    @Test
+    fun `channel enable without group returns usage error`() {
+        val result = eventGateway.process(buildMessage("channel enable", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals(
+            "Usage: channel enable <group> [for <pattern>]",
+            (result as OperationResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `channel set without enough args returns usage error`() {
+        val result =
+            eventGateway.process(buildMessage("channel set test-admin-op onlyKey", Role.ADMIN))
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertEquals(
+            "Usage: channel set <group> <key> <value> [for <pattern>]",
+            (result as OperationResult.Error).message,
+        )
+    }
+
+    @Test
+    fun `channel set with value and for clause stores scoped config`() {
+        val result =
+            eventGateway.process(
+                buildMessage(
+                    "channel set test-admin-op greeting hello there for irc://oftc/%23kotlin",
+                    Role.ADMIN,
+                )
+            )
+        assertInstanceOf(OperationResult.Success::class.java, result)
+
+        val config = configService.findConfig("irc://oftc/%23kotlin", "test-admin-op")
+        assertEquals("hello there", config!!.config["greeting"])
+    }
+
+    @Test
+    fun `channel config without provenance suggests for clause`() {
+        val message = MessageBuilder.withPayload("channel config").build()
+        val result = eventGateway.process(message)
+        assertInstanceOf(OperationResult.Error::class.java, result)
+        assertTrue(
+            (result as OperationResult.Error).message.contains("Cannot determine target provenance")
+        )
     }
 }

--- a/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/operation/GetFactoidOperation.kt
+++ b/operation-factoid/src/main/kotlin/com/enigmastation/streampack/factoid/operation/GetFactoidOperation.kt
@@ -37,10 +37,11 @@ class GetFactoidOperation(
     override fun handle(payload: FactoidQueryRequest, message: Message<*>): OperationOutcome? {
         return try {
             val searchResult =
-                factoidService.findSelectorWithArguments(payload.selector) ?: return null
+                factoidService.findSelectorWithArguments(payload.selector)
+                    ?: return missingSelectorOutcome(payload)
             val (selector, argument) = searchResult
             val attributes = factoidService.findBySelector(selector)
-            if (attributes.isEmpty()) return null
+            if (attributes.isEmpty()) return missingSelectorOutcome(payload)
 
             // Follow .see redirects for default queries
             if (payload.attribute == FactoidAttributeType.UNKNOWN) {
@@ -82,6 +83,18 @@ class GetFactoidOperation(
             OperationResult.Error(e.message!!)
         } catch (_: TooManyArgumentsException) {
             null
+        }
+    }
+
+    private fun missingSelectorOutcome(payload: FactoidQueryRequest): OperationOutcome? {
+        return when (payload.attribute) {
+            FactoidAttributeType.INFO,
+            FactoidAttributeType.LITERAL,
+            FactoidAttributeType.LOCK,
+            FactoidAttributeType.UNLOCK,
+            FactoidAttributeType.STATS ->
+                OperationResult.Error("Factoid '${payload.selector}' not found.")
+            else -> null
         }
     }
 

--- a/operation-factoid/src/test/kotlin/com/enigmastation/streampack/factoid/operation/FactoidOperationTests.kt
+++ b/operation-factoid/src/test/kotlin/com/enigmastation/streampack/factoid/operation/FactoidOperationTests.kt
@@ -163,6 +163,28 @@ class FactoidOperationTests {
         assertError(result)
     }
 
+    @Test
+    fun `unlock from non-admin returns error`() {
+        eventGateway.process(msg("unlocktest=value"))
+        eventGateway.process(msg("unlocktest.lock", role = Role.ADMIN))
+        val result = eventGateway.process(msg("unlocktest.unlock", role = Role.USER))
+        assertError(result)
+    }
+
+    @Test
+    fun `unlock from admin succeeds`() {
+        eventGateway.process(msg("unlocktest2=value"))
+        eventGateway.process(msg("unlocktest2.lock", role = Role.ADMIN))
+        val result = eventGateway.process(msg("unlocktest2.unlock", role = Role.ADMIN))
+        assertSuccess(result, "ok, unlocktest2 is now unlocked.")
+    }
+
+    @Test
+    fun `unlock on nonexistent factoid returns error`() {
+        val result = eventGateway.process(msg("ghost.unlock", role = Role.ADMIN))
+        assertError(result)
+    }
+
     // -- Case insensitive --
 
     @Test


### PR DESCRIPTION
* This is mostly a code coverage repair.
* There's still room to improve coverage.
* The only runtime change here is nearly invisible to users: using .forget on a nonexistent factoid is a different type of response.

Fixes #215
