### PR TITLE
spinner and API versioning

### DIFF
--- a/docs/api-version-headers.md
+++ b/docs/api-version-headers.md
@@ -1,0 +1,21 @@
+# API Version Headers (Advisory Mode)
+
+ByteCode.News supports header-based API version signaling in advisory mode.
+
+## Request Header
+
+- `Accept-Version` (optional): client-requested API contract version.
+
+## Response Headers
+
+- `Content-Version`: server's current API contract version.
+- `Accept-Version`: resolved request version used for this response.
+
+## Current Behavior
+
+- If `Accept-Version` is absent, the server resolves to the current version.
+- If `Accept-Version` is recognized, it is echoed back.
+- If `Accept-Version` is unrecognized, behavior falls back to current version and a warning is logged.
+
+No endpoint behavior changes are currently version-gated. This is scaffolding for future, explicit version routing.
+

--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -929,7 +929,7 @@
     }
   },
   "info" : {
-    "description" : "Content hub and knowledge management for the JVM ecosystem",
+    "description" : "Content hub and knowledge management for the JVM ecosystem. Advisory version headers are supported: clients may send 'Accept-Version' and responses include 'Content-Version' and resolved 'Accept-Version'.",
     "title" : "bytecode.news API",
     "version" : "0.1.0"
   },

--- a/reference-ui/src/views/post-detail.js
+++ b/reference-ui/src/views/post-detail.js
@@ -61,6 +61,7 @@ export async function render(container, params) {
       } else {
         treeEl.innerHTML = "<p>No comments yet.</p>";
       }
+      treeEl.removeAttribute("aria-busy");
 
       // Top-level comment form for logged-in users
       if (isLoggedIn()) {
@@ -86,7 +87,9 @@ export async function render(container, params) {
         });
       }
     } catch (err) {
-      document.getElementById("comment-tree").innerHTML = "<p>Could not load comments.</p>";
+      const treeEl = document.getElementById("comment-tree");
+      treeEl.innerHTML = "<p>Could not load comments.</p>";
+      treeEl.removeAttribute("aria-busy");
     }
   } catch (err) {
     renderError(container, err);

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/config/ApiVersionHeaderFilter.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/config/ApiVersionHeaderFilter.kt
@@ -1,0 +1,62 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.blog.config
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Component
+import org.springframework.web.filter.OncePerRequestFilter
+
+/**
+ * Advisory API version headers.
+ *
+ * `Accept-Version` is optional and currently non-breaking: unsupported values fall back to current
+ * behavior, but are logged. `Content-Version` always reflects the server's current contract
+ * version.
+ */
+@Component
+class ApiVersionHeaderFilter(
+    @Value("\${streampack.api.version.current:2026-03-10}") private val currentVersion: String,
+    @Value("\${streampack.api.version.supported:}") supportedVersionsRaw: String,
+) : OncePerRequestFilter() {
+
+    private val logger = LoggerFactory.getLogger(ApiVersionHeaderFilter::class.java)
+    private val supportedVersions: Set<String> =
+        (supportedVersionsRaw.split(",").map { it.trim() }.filter { it.isNotEmpty() } +
+                currentVersion)
+            .toSet()
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val requested = request.getHeader(ACCEPT_VERSION_HEADER)?.trim()?.takeIf { it.isNotEmpty() }
+        val resolved =
+            when {
+                requested == null -> currentVersion
+                requested in supportedVersions -> requested
+                else -> {
+                    logger.warn(
+                        "Unknown Accept-Version '{}' for {} {}; defaulting to '{}'",
+                        requested,
+                        request.method,
+                        request.requestURI,
+                        currentVersion,
+                    )
+                    currentVersion
+                }
+            }
+
+        response.setHeader(CONTENT_VERSION_HEADER, currentVersion)
+        response.setHeader(ACCEPT_VERSION_HEADER, resolved)
+        filterChain.doFilter(request, response)
+    }
+
+    companion object {
+        const val ACCEPT_VERSION_HEADER = "Accept-Version"
+        const val CONTENT_VERSION_HEADER = "Content-Version"
+    }
+}

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/config/OpenApiConfiguration.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/config/OpenApiConfiguration.kt
@@ -19,7 +19,12 @@ class OpenApiConfiguration {
                 Info()
                     .title("bytecode.news API")
                     .version("0.1.0")
-                    .description("Content hub and knowledge management for the JVM ecosystem")
+                    .description(
+                        "Content hub and knowledge management for the JVM ecosystem. " +
+                            "Advisory version headers are supported: clients may send " +
+                            "'Accept-Version' and responses include 'Content-Version' and " +
+                            "resolved 'Accept-Version'."
+                    )
             )
             .components(
                 Components()

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/WebSecurityConfiguration.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/WebSecurityConfiguration.kt
@@ -34,7 +34,8 @@ class WebSecurityConfiguration(
         val config = CorsConfiguration()
         config.allowedOrigins = corsOrigins.split(",").map { it.trim() }
         config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        config.allowedHeaders = listOf("Authorization", "Content-Type", "Accept")
+        config.allowedHeaders = listOf("Authorization", "Content-Type", "Accept", "Accept-Version")
+        config.exposedHeaders = listOf("Content-Version", "Accept-Version")
         config.maxAge = 3600L
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", config)

--- a/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/ApiVersionHeaderFilterTests.kt
+++ b/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/ApiVersionHeaderFilterTests.kt
@@ -1,0 +1,58 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.blog.controller
+
+import com.enigmastation.streampack.test.TestChannelConfiguration
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.boot.webmvc.test.autoconfigure.AutoConfigureMockMvc
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.get
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest(
+    properties =
+        [
+            "streampack.api.version.current=2026-03-10",
+            "streampack.api.version.supported=2026-03-10,2026-04-01",
+        ]
+)
+@AutoConfigureMockMvc
+@Transactional
+@Import(TestChannelConfiguration::class)
+class ApiVersionHeaderFilterTests {
+
+    @Autowired lateinit var mockMvc: MockMvc
+
+    @Test
+    fun `response includes default version headers when request header is absent`() {
+        mockMvc.get("/posts").andExpect {
+            status { isOk() }
+            header { string("Content-Version", "2026-03-10") }
+            header { string("Accept-Version", "2026-03-10") }
+        }
+    }
+
+    @Test
+    fun `supported Accept-Version is echoed in response`() {
+        mockMvc
+            .get("/posts") { header("Accept-Version", "2026-04-01") }
+            .andExpect {
+                status { isOk() }
+                header { string("Content-Version", "2026-03-10") }
+                header { string("Accept-Version", "2026-04-01") }
+            }
+    }
+
+    @Test
+    fun `unsupported Accept-Version falls back to current version`() {
+        mockMvc
+            .get("/posts") { header("Accept-Version", "2099-01-01") }
+            .andExpect {
+                status { isOk() }
+                header { string("Content-Version", "2026-03-10") }
+                header { string("Accept-Version", "2026-03-10") }
+            }
+    }
+}


### PR DESCRIPTION
* Trying to clear errant spinner update on comment load
* Adding no-op version and content-version headers for the API

Fixes #232
Fixes #231
