### PR TITLE
Add admin dashboard, shared layout, and redesign admin pages

### DIFF
--- a/ui-nextjs/src/app/admin/layout.tsx
+++ b/ui-nextjs/src/app/admin/layout.tsx
@@ -1,0 +1,31 @@
+import { AdminNav } from "@/components/admin-nav";
+
+export default function AdminLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return (
+    <section className="py-8 md:py-12">
+      <div className="max-w-4xl mx-auto px-6 md:px-8">
+        <header className="mb-8">
+          <div className="border-t-2 border-amber animate-rule-draw" />
+          <div className="pt-6 pb-6">
+            <p className="section-label text-amber mb-3">Administration</p>
+            <h1
+              className="font-display text-foreground leading-tight"
+              style={{
+                fontSize: "clamp(2rem, 5vw, 3rem)",
+                letterSpacing: "-0.025em",
+              }}
+            >
+              Site Management
+            </h1>
+          </div>
+          <AdminNav />
+        </header>
+        {children}
+      </div>
+    </section>
+  );
+}

--- a/ui-nextjs/src/app/admin/page.tsx
+++ b/ui-nextjs/src/app/admin/page.tsx
@@ -1,0 +1,5 @@
+import { AdminDashboard } from "@/components/admin-dashboard";
+
+export default function AdminPage() {
+  return <AdminDashboard />;
+}

--- a/ui-nextjs/src/app/api/features/route.ts
+++ b/ui-nextjs/src/app/api/features/route.ts
@@ -1,0 +1,18 @@
+import { getBackendBaseUrl } from "@/lib/backend-url";
+
+export async function GET() {
+  const response = await fetch(`${getBackendBaseUrl()}/features`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") || "application/json",
+    },
+  });
+}

--- a/ui-nextjs/src/app/api/posts/route.ts
+++ b/ui-nextjs/src/app/api/posts/route.ts
@@ -1,5 +1,29 @@
 import { getBackendBaseUrl } from "@/lib/backend-url";
 
+export async function GET(request: Request) {
+  const url = new URL(request.url);
+  const params = new URLSearchParams();
+  for (const key of ["page", "size", "category", "tag"]) {
+    const val = url.searchParams.get(key);
+    if (val) params.set(key, val);
+  }
+
+  const response = await fetch(`${getBackendBaseUrl()}/posts?${params.toString()}`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") || "application/json",
+    },
+  });
+}
+
 export async function POST(request: Request) {
   const payload = await request.text();
   const auth = request.headers.get("authorization");

--- a/ui-nextjs/src/app/api/taxonomy/route.ts
+++ b/ui-nextjs/src/app/api/taxonomy/route.ts
@@ -1,0 +1,18 @@
+import { getBackendBaseUrl } from "@/lib/backend-url";
+
+export async function GET() {
+  const response = await fetch(`${getBackendBaseUrl()}/taxonomy`, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+    cache: "no-store",
+  });
+
+  return new Response(await response.text(), {
+    status: response.status,
+    headers: {
+      "Content-Type": response.headers.get("content-type") || "application/json",
+    },
+  });
+}

--- a/ui-nextjs/src/components/admin-categories.tsx
+++ b/ui-nextjs/src/components/admin-categories.tsx
@@ -89,9 +89,9 @@ export function AdminCategories() {
     }
   }
 
-  async function onDelete(id: string) {
+  async function onDelete(id: string, categoryName: string) {
     if (!auth.token) return;
-    if (!window.confirm("Delete this category?")) return;
+    if (!window.confirm(`Delete the "${categoryName}" category?`)) return;
 
     setBusy(true);
     setStatus(null);
@@ -118,87 +118,155 @@ export function AdminCategories() {
 
   if (!auth.token || !isAdmin) {
     return (
-      <section className="notice">
-        <h2>Manage Categories</h2>
-        <p>Admin access required.</p>
-      </section>
+      <div className="py-12 text-center">
+        <p className="section-label text-muted-foreground">
+          Admin access required.
+        </p>
+      </div>
     );
   }
 
+  const topLevel = categories.filter((c) => !c.parentName);
+  const children = categories.filter((c) => c.parentName);
+
   return (
-    <section className="auth-shell submit-shell">
-      <h2 className="auth-title">Manage Categories</h2>
-      <form className="auth-form" onSubmit={onCreate}>
-        <label className="auth-label" htmlFor="category-name">
-          New category
-        </label>
-        <input
-          id="category-name"
-          className="auth-input"
-          value={name}
-          onChange={(event) => setName(event.target.value)}
-          required
-        />
-
-        <label className="auth-label" htmlFor="category-parent">
-          Parent (optional)
-        </label>
-        <select
-          id="category-parent"
-          className="auth-input"
-          value={parentId}
-          onChange={(event) => setParentId(event.target.value)}
-        >
-          <option value="">(top-level)</option>
-          {categories.map((category) => (
-            <option key={category.id} value={category.id}>
-              {category.name}
-            </option>
-          ))}
-        </select>
-
-        <div className="auth-actions">
-          <button type="submit" className="auth-button" disabled={busy}>
-            {busy ? "Saving..." : "Create category"}
-          </button>
+    <div>
+      {/* Create form */}
+      <form
+        className="mb-8 p-5 border border-border/40"
+        onSubmit={onCreate}
+      >
+        <h3 className="section-label text-amber mb-4">New Category</h3>
+        <div className="grid grid-cols-1 sm:grid-cols-3 gap-3 items-end">
+          <div>
+            <label className="byline text-muted-foreground/50 block mb-1.5" htmlFor="category-name">
+              Name
+            </label>
+            <input
+              id="category-name"
+              className="w-full border border-border bg-background text-foreground p-2 text-sm focus:outline-none focus:ring-1 focus:ring-amber"
+              style={{ fontFamily: "var(--font-body), Georgia, serif" }}
+              value={name}
+              onChange={(event) => setName(event.target.value)}
+              required
+            />
+          </div>
+          <div>
+            <label className="byline text-muted-foreground/50 block mb-1.5" htmlFor="category-parent">
+              Parent
+            </label>
+            <select
+              id="category-parent"
+              className="w-full border border-border bg-background text-foreground p-2 text-sm focus:outline-none focus:ring-1 focus:ring-amber appearance-none cursor-pointer"
+              style={{ fontFamily: "var(--font-body), Georgia, serif" }}
+              value={parentId}
+              onChange={(event) => setParentId(event.target.value)}
+            >
+              <option value="">(top-level)</option>
+              {categories.map((category) => (
+                <option key={category.id} value={category.id}>
+                  {category.name}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <button type="submit" className="auth-button w-full" disabled={busy}>
+              {busy ? "Creating..." : "Create"}
+            </button>
+          </div>
         </div>
       </form>
 
-      {loading ? <p>Loading categories...</p> : null}
-      {!loading && categories.length === 0 ? <p>No categories yet.</p> : null}
+      {/* Status / error messages */}
+      {status && (
+        <div className="mb-6 px-4 py-3 border border-amber/30 bg-amber/5">
+          <p className="section-label text-amber">{status}</p>
+        </div>
+      )}
+      {error && (
+        <div className="mb-6 px-4 py-3 border border-destructive/30 bg-destructive/5">
+          <p className="section-label text-destructive">{error}</p>
+        </div>
+      )}
 
-      {!loading && categories.length > 0 ? (
-        <table className="factoid-table" role="grid">
-          <thead>
-            <tr>
-              <th>Name</th>
-              <th>Parent</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {categories.map((category) => (
-              <tr key={category.id}>
-                <td>{category.name}</td>
-                <td>{category.parentName || "(top-level)"}</td>
-                <td>
+      {loading ? (
+        <div className="py-12 text-center">
+          <p className="section-label text-muted-foreground/50">Loading categories...</p>
+        </div>
+      ) : categories.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="section-label text-muted-foreground/50 mb-3">No categories yet</p>
+          <p className="text-muted-foreground/40 text-sm">
+            Create your first category above.
+          </p>
+        </div>
+      ) : (
+        <div className="animate-fade-in">
+          {topLevel.map((category, i) => {
+            const subcategories = children.filter((c) => c.parentName === category.name);
+            return (
+              <div
+                key={category.id}
+                className={`py-5 ${i > 0 ? "border-t border-border/30" : ""}`}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <h3 className="headline-brief text-foreground">
+                      {category.name}
+                    </h3>
+                    {subcategories.length > 0 && (
+                      <div className="flex flex-wrap gap-2 mt-2">
+                        {subcategories.map((sub) => (
+                          <span key={sub.id} className="tag">
+                            {sub.name}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
                   <button
                     type="button"
-                    className="auth-button secondary"
+                    className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors shrink-0 disabled:opacity-50"
                     disabled={busy}
-                    onClick={() => onDelete(category.id)}
+                    onClick={() => onDelete(category.id, category.name)}
                   >
                     Delete
                   </button>
-                </td>
-              </tr>
+                </div>
+              </div>
+            );
+          })}
+          {/* Show orphaned children (parent not in top-level list) */}
+          {children
+            .filter((c) => !topLevel.some((t) => t.name === c.parentName))
+            .map((category, i) => (
+              <div
+                key={category.id}
+                className={`py-5 border-t border-border/30`}
+              >
+                <div className="flex items-center justify-between gap-4">
+                  <div>
+                    <h3 className="headline-brief text-foreground">
+                      {category.name}
+                    </h3>
+                    <p className="byline text-muted-foreground/50 mt-1">
+                      Child of {category.parentName}
+                    </p>
+                  </div>
+                  <button
+                    type="button"
+                    className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors shrink-0 disabled:opacity-50"
+                    disabled={busy}
+                    onClick={() => onDelete(category.id, category.name)}
+                  >
+                    Delete
+                  </button>
+                </div>
+              </div>
             ))}
-          </tbody>
-        </table>
-      ) : null}
-
-      {status ? <p className="auth-status">{status}</p> : null}
-      {error ? <p className="auth-error">{error}</p> : null}
-    </section>
+        </div>
+      )}
+    </div>
   );
 }

--- a/ui-nextjs/src/components/admin-dashboard.tsx
+++ b/ui-nextjs/src/components/admin-dashboard.tsx
@@ -1,0 +1,310 @@
+"use client";
+
+import Link from "next/link";
+import { useEffect, useState } from "react";
+import { getAuthState } from "@/lib/client-auth";
+import { CategorySummary, ContentListResponse, FeaturesResponse, TaxonomySnapshot } from "@/lib/types";
+
+type UserPrincipal = {
+  id: string;
+  username: string;
+  displayName: string;
+  role: string;
+};
+
+interface DashboardData {
+  pendingCount: number | null;
+  publishedCount: number | null;
+  activeUserCount: number | null;
+  suspendedUserCount: number | null;
+  categories: CategorySummary[] | null;
+  taxonomy: TaxonomySnapshot | null;
+  features: FeaturesResponse | null;
+}
+
+function StatCard({
+  label,
+  value,
+  href,
+}: {
+  label: string;
+  value: string | number;
+  href?: string;
+}) {
+  const inner = (
+    <div className="border border-border/40 p-5 group hover:border-amber/40 transition-colors">
+      <p className="section-label text-muted-foreground/60 mb-2">{label}</p>
+      <p
+        className="font-display text-foreground leading-none"
+        style={{ fontSize: "clamp(1.8rem, 4vw, 2.5rem)", letterSpacing: "-0.02em" }}
+      >
+        {value}
+      </p>
+    </div>
+  );
+
+  if (href) {
+    return <Link href={href}>{inner}</Link>;
+  }
+  return inner;
+}
+
+export function AdminDashboard() {
+  const [data, setData] = useState<DashboardData>({
+    pendingCount: null,
+    publishedCount: null,
+    activeUserCount: null,
+    suspendedUserCount: null,
+    categories: null,
+    taxonomy: null,
+    features: null,
+  });
+  const [loading, setLoading] = useState(true);
+
+  const auth = getAuthState();
+  const isAdmin =
+    auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
+
+  useEffect(() => {
+    if (!auth.token || !isAdmin) {
+      setLoading(false);
+      return;
+    }
+
+    async function load() {
+      const headers = {
+        Accept: "application/json",
+        Authorization: `Bearer ${auth.token}`,
+      };
+
+      const results = await Promise.allSettled([
+        fetch("/api/admin/posts/pending?page=0&size=1&deleted=false", {
+          headers,
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<ContentListResponse>),
+
+        fetch("/api/posts?page=0&size=1", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<ContentListResponse>),
+
+        fetch("/api/admin/users?status=ACTIVE", {
+          headers,
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<UserPrincipal[]>),
+
+        fetch("/api/admin/users?status=SUSPENDED", {
+          headers,
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<UserPrincipal[]>),
+
+        fetch("/api/categories", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<CategorySummary[]>),
+
+        fetch("/api/taxonomy", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<TaxonomySnapshot>),
+
+        fetch("/api/features", {
+          headers: { Accept: "application/json" },
+          cache: "no-store",
+        }).then((r) => r.json() as Promise<FeaturesResponse>),
+      ]);
+
+      setData({
+        pendingCount:
+          results[0].status === "fulfilled" ? results[0].value.totalCount : null,
+        publishedCount:
+          results[1].status === "fulfilled" ? results[1].value.totalCount : null,
+        activeUserCount:
+          results[2].status === "fulfilled" ? results[2].value.length : null,
+        suspendedUserCount:
+          results[3].status === "fulfilled" ? results[3].value.length : null,
+        categories:
+          results[4].status === "fulfilled" ? results[4].value : null,
+        taxonomy:
+          results[5].status === "fulfilled" ? results[5].value : null,
+        features:
+          results[6].status === "fulfilled" ? results[6].value : null,
+      });
+      setLoading(false);
+    }
+
+    void load();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  if (!auth.token || !isAdmin) {
+    return (
+      <div className="py-12 text-center">
+        <p className="section-label text-muted-foreground">
+          Admin access required.
+        </p>
+      </div>
+    );
+  }
+
+  if (loading) {
+    return (
+      <div className="py-12 text-center">
+        <p className="section-label text-muted-foreground/50">
+          Loading dashboard...
+        </p>
+      </div>
+    );
+  }
+
+  const categoryCounts = data.taxonomy?.categories ?? {};
+  const tagEntries = data.taxonomy
+    ? Object.entries(data.taxonomy.tags).sort(([, a], [, b]) => b - a)
+    : [];
+
+  return (
+    <div className="animate-fade-in">
+      {/* Stats grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-10">
+        <StatCard
+          label="Pending Drafts"
+          value={data.pendingCount ?? "--"}
+          href="/admin/pending"
+        />
+        <StatCard
+          label="Published"
+          value={data.publishedCount ?? "--"}
+        />
+        <StatCard
+          label="Active Users"
+          value={data.activeUserCount ?? "--"}
+          href="/admin/users"
+        />
+        <StatCard
+          label="Suspended"
+          value={data.suspendedUserCount ?? "--"}
+        />
+      </div>
+
+      {/* Two-column: Categories + Tags */}
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-8 mb-10">
+        {/* Categories */}
+        <div>
+          <div className="flex items-center justify-between mb-4 border-b border-border/40 pb-3">
+            <h2 className="section-label text-amber">Categories</h2>
+            <Link
+              href="/admin/categories"
+              className="section-label text-muted-foreground hover:text-amber transition-colors"
+            >
+              Manage
+            </Link>
+          </div>
+          {!data.categories || data.categories.length === 0 ? (
+            <p className="text-muted-foreground/50 text-sm">No categories yet.</p>
+          ) : (
+            <div className="space-y-2">
+              {data.categories.map((cat) => (
+                <div
+                  key={cat.id}
+                  className="flex items-center justify-between py-1.5"
+                >
+                  <div className="truncate mr-4">
+                    <Link
+                      href={`/category/${encodeURIComponent(cat.name)}`}
+                      className="text-sm text-foreground hover:text-amber transition-colors"
+                    >
+                      {cat.name}
+                    </Link>
+                    {cat.parentName && (
+                      <span className="dateline text-muted-foreground/40 ml-2">
+                        in {cat.parentName}
+                      </span>
+                    )}
+                  </div>
+                  <span className="dateline text-muted-foreground/50 shrink-0">
+                    {categoryCounts[cat.name.toLowerCase()] ?? 0} posts
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Top tags */}
+        <div>
+          <div className="flex items-center justify-between mb-4 border-b border-border/40 pb-3">
+            <h2 className="section-label text-amber">Top Tags</h2>
+            <Link
+              href="/tags"
+              className="section-label text-muted-foreground hover:text-amber transition-colors"
+            >
+              View All
+            </Link>
+          </div>
+          {tagEntries.length === 0 ? (
+            <p className="text-muted-foreground/50 text-sm">No tags yet.</p>
+          ) : (
+            <div className="flex flex-wrap gap-2">
+              {tagEntries.slice(0, 20).map(([name, count]) => (
+                <Link
+                  key={name}
+                  href={`/tags/${encodeURIComponent(name)}`}
+                  className="tag hover:border-amber/40 hover:text-amber transition-colors"
+                >
+                  {name} ({count})
+                </Link>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* System info */}
+      {data.features && (
+        <div className="border-t border-border/40 pt-6">
+          <h2 className="section-label text-amber mb-4">System</h2>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3">
+            <div className="flex items-baseline gap-2">
+              <span className="dateline text-muted-foreground/50">Site</span>
+              <span className="text-sm text-foreground">{data.features.siteName}</span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="dateline text-muted-foreground/50">Build</span>
+              <span className="text-sm text-foreground">
+                {data.features.version.commit?.substring(0, 7) ?? "unknown"}
+                {data.features.version.branch
+                  ? ` (${data.features.version.branch})`
+                  : ""}
+              </span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="dateline text-muted-foreground/50">Auth</span>
+              <span className="text-sm text-foreground">
+                {[
+                  data.features.authentication.otp ? "OTP" : null,
+                  data.features.authentication.oidc?.google ? "Google" : null,
+                  data.features.authentication.oidc?.github ? "GitHub" : null,
+                ]
+                  .filter(Boolean)
+                  .join(", ") || "None"}
+              </span>
+            </div>
+            <div className="flex items-baseline gap-2">
+              <span className="dateline text-muted-foreground/50">AI</span>
+              <span className="text-sm text-foreground">
+                {data.features.ai ? "Enabled" : "Disabled"}
+              </span>
+            </div>
+            {data.features.adapters.length > 0 && (
+              <div className="flex items-baseline gap-2 sm:col-span-2">
+                <span className="dateline text-muted-foreground/50">Adapters</span>
+                <span className="text-sm text-foreground">
+                  {data.features.adapters.join(", ")}
+                </span>
+              </div>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ui-nextjs/src/components/admin-nav.tsx
+++ b/ui-nextjs/src/components/admin-nav.tsx
@@ -1,0 +1,39 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+const adminLinks = [
+  { href: "/admin", label: "Dashboard" },
+  { href: "/admin/pending", label: "Pending Drafts" },
+  { href: "/admin/users", label: "Users" },
+  { href: "/admin/categories", label: "Categories" },
+];
+
+export function AdminNav() {
+  const pathname = usePathname();
+
+  return (
+    <nav className="flex gap-0 border-b border-border/40">
+      {adminLinks.map((link) => {
+        const active = link.href === "/admin"
+          ? pathname === "/admin"
+          : pathname.startsWith(link.href);
+
+        return (
+          <Link
+            key={link.href}
+            href={link.href}
+            className={`section-label px-4 py-3 -mb-px transition-colors whitespace-nowrap ${
+              active
+                ? "text-amber border-b-2 border-amber"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {link.label}
+          </Link>
+        );
+      })}
+    </nav>
+  );
+}

--- a/ui-nextjs/src/components/admin-pending-posts.tsx
+++ b/ui-nextjs/src/components/admin-pending-posts.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useCallback } from "react";
 import { getAuthState } from "@/lib/client-auth";
 import { formatDate } from "@/lib/format";
-import { ContentListResponse, ContentSummary } from "@/lib/types";
+import { ContentListResponse, ContentSummary, ContentDetail } from "@/lib/types";
+import { HighlightedHtml } from "@/components/highlighted-html";
 
 type ProblemLike = { detail?: string; title?: string; message?: string };
 
@@ -16,6 +17,84 @@ function detailMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
+function displayAuthor(name: string | undefined): string {
+  if (!name || name === "UNKNOWN") return "Unattributed";
+  return name;
+}
+
+function ReaderPreview({
+  post,
+  onClose,
+}: {
+  post: ContentDetail;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center overflow-y-auto bg-background/80 backdrop-blur-sm"
+      onClick={(e) => {
+        if (e.target === e.currentTarget) onClose();
+      }}
+    >
+      <div className="relative w-full max-w-3xl mx-4 my-8 bg-background border border-border shadow-lg">
+        {/* Pending banner */}
+        <div className="bg-amber/10 border-b border-amber/30 px-6 py-3 flex items-center justify-between">
+          <span className="section-label text-amber">
+            Draft Preview &mdash; Not Published
+          </span>
+          <button
+            type="button"
+            onClick={onClose}
+            className="section-label text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Close
+          </button>
+        </div>
+
+        {/* Article content mirroring the real article page */}
+        <article className="px-6 md:px-8 py-8">
+          <header>
+            <div className="border-t-2 border-amber/50 border-dashed mb-6" />
+            <h1 className="headline-lead text-foreground mb-4">{post.title}</h1>
+            <div className="byline text-muted-foreground flex items-center gap-1.5 flex-wrap">
+              <span>By {displayAuthor(post.authorDisplayName)}</span>
+              {post.publishedAt && (
+                <>
+                  <span className="text-border/60 mx-1">|</span>
+                  <time dateTime={post.publishedAt}>
+                    {formatDate(post.publishedAt)}
+                  </time>
+                </>
+              )}
+            </div>
+          </header>
+
+          {post.tags.length > 0 && (
+            <div className="tags mt-4">
+              {post.tags.map((tag) => (
+                <span className="tag" key={tag}>
+                  {tag}
+                </span>
+              ))}
+            </div>
+          )}
+
+          <div className="border-t border-border/40 mt-6 mb-6" />
+
+          <HighlightedHtml className="post-body" html={post.renderedHtml} />
+        </article>
+
+        {/* Bottom pending banner */}
+        <div className="bg-amber/10 border-t border-amber/30 px-6 py-3">
+          <span className="section-label text-amber">
+            End of Draft Preview
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
 export function AdminPendingPosts() {
   const [posts, setPosts] = useState<ContentSummary[]>([]);
   const [showDeleted, setShowDeleted] = useState(false);
@@ -23,11 +102,15 @@ export function AdminPendingPosts() {
   const [busyId, setBusyId] = useState<string | null>(null);
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [previewPost, setPreviewPost] = useState<ContentDetail | null>(null);
+  const [previewLoading, setPreviewLoading] = useState<string | null>(null);
 
   const auth = getAuthState();
-  const isAdmin = auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
+  const isAdmin =
+    auth.principal?.role === "ADMIN" ||
+    auth.principal?.role === "SUPER_ADMIN";
 
-  async function loadPending() {
+  const loadPending = useCallback(async () => {
     if (!auth.token || !isAdmin) {
       setLoading(false);
       return;
@@ -38,29 +121,35 @@ export function AdminPendingPosts() {
       const response = await fetch(
         `/api/admin/posts/pending?page=0&size=50&deleted=${showDeleted ? "true" : "false"}`,
         {
-        headers: {
-          Accept: "application/json",
-          Authorization: `Bearer ${auth.token}`,
+          headers: {
+            Accept: "application/json",
+            Authorization: `Bearer ${auth.token}`,
+          },
+          cache: "no-store",
         },
-        cache: "no-store",
-      },
       );
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
-        throw new Error(detailMessage(payload, "Could not load pending posts."));
+        throw new Error(
+          detailMessage(payload, "Could not load pending posts."),
+        );
       }
       const list = payload as ContentListResponse;
       setPosts(list.posts || []);
     } catch (loadError) {
-      setError(loadError instanceof Error ? loadError.message : "Could not load pending posts.");
+      setError(
+        loadError instanceof Error
+          ? loadError.message
+          : "Could not load pending posts.",
+      );
     } finally {
       setLoading(false);
     }
-  }
+  }, [auth.token, isAdmin, showDeleted]);
 
   useEffect(() => {
     void loadPending();
-  }, [showDeleted]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [loadPending]);
 
   async function approve(postId: string) {
     if (!auth.token) return;
@@ -83,122 +172,250 @@ export function AdminPendingPosts() {
       setStatus("Post approved.");
       await loadPending();
     } catch (approveError) {
-      setError(approveError instanceof Error ? approveError.message : "Could not approve post.");
+      setError(
+        approveError instanceof Error
+          ? approveError.message
+          : "Could not approve post.",
+      );
     } finally {
       setBusyId(null);
     }
   }
 
   async function remove(postId: string, hard: boolean) {
+    const message = hard
+      ? "Permanently delete this post? This cannot be undone."
+      : "Delete this draft? It can be restored later.";
+    if (!window.confirm(message)) return;
+
     if (!auth.token) return;
     setBusyId(postId);
     setStatus(null);
     setError(null);
     try {
-      const response = await fetch(`/api/admin/posts/${postId}?hard=${hard ? "true" : "false"}`, {
-        method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
+      const response = await fetch(
+        `/api/admin/posts/${postId}?hard=${hard ? "true" : "false"}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${auth.token}`,
+          },
         },
-      });
+      );
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
         throw new Error(detailMessage(payload, "Could not delete post."));
       }
-      setStatus(hard ? "Post hard-deleted." : "Post deleted.");
+      setStatus(hard ? "Post permanently deleted." : "Post deleted.");
       await loadPending();
     } catch (removeError) {
-      setError(removeError instanceof Error ? removeError.message : "Could not delete post.");
+      setError(
+        removeError instanceof Error
+          ? removeError.message
+          : "Could not delete post.",
+      );
     } finally {
       setBusyId(null);
     }
   }
 
-  if (!auth.token || !isAdmin) {
-    return (
-      <section className="notice">
-        <h2>Pending Drafts</h2>
-        <p>Admin access required.</p>
-      </section>
-    );
+  async function openPreview(postId: string) {
+    if (!auth.token) return;
+    setPreviewLoading(postId);
+    try {
+      const response = await fetch(`/api/post-by-id/${postId}`, {
+        headers: {
+          Accept: "application/json",
+          Authorization: `Bearer ${auth.token}`,
+        },
+        cache: "no-store",
+      });
+      const payload = (await response.json()) as unknown;
+      if (!response.ok) {
+        throw new Error(detailMessage(payload, "Could not load post preview."));
+      }
+      setPreviewPost(payload as ContentDetail);
+    } catch (previewError) {
+      setError(
+        previewError instanceof Error
+          ? previewError.message
+          : "Could not load preview.",
+      );
+    } finally {
+      setPreviewLoading(null);
+    }
   }
 
-  if (loading) {
+  if (!auth.token || !isAdmin) {
     return (
-      <section className="notice">
-        <p>Loading pending drafts...</p>
-      </section>
+      <div className="py-12 text-center">
+        <p className="section-label text-muted-foreground">
+          Admin access required.
+        </p>
+      </div>
     );
   }
 
   return (
-    <section className="auth-shell submit-shell">
-      <h2 className="auth-title">Pending Drafts</h2>
-      <div className="auth-actions">
-        <button
-          type="button"
-          className="auth-button secondary"
-          disabled={busyId !== null}
-          onClick={() => setShowDeleted(false)}
-        >
-          Active drafts
-        </button>
-        <button
-          type="button"
-          className="auth-button secondary"
-          disabled={busyId !== null}
-          onClick={() => setShowDeleted(true)}
-        >
-          Deleted drafts
-        </button>
-      </div>
-      {posts.length === 0 ? <p className="auth-note">No pending drafts.</p> : null}
+    <div>
+      {/* Tab switcher */}
+      <nav className="flex gap-0 mb-6 border-b border-border/40">
+          <button
+            type="button"
+            onClick={() => setShowDeleted(false)}
+            disabled={busyId !== null}
+            className={`section-label px-4 py-3 -mb-px transition-colors ${
+              !showDeleted
+                ? "text-amber border-b-2 border-amber"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Active
+          </button>
+          <button
+            type="button"
+            onClick={() => setShowDeleted(true)}
+            disabled={busyId !== null}
+            className={`section-label px-4 py-3 -mb-px transition-colors ${
+              showDeleted
+                ? "text-amber border-b-2 border-amber"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            Deleted
+          </button>
+        </nav>
 
-      {posts.map((post) => (
-        <article className="story-card" key={post.id}>
-          <div className="meta">
-            {formatDate(post.publishedAt)} | {post.authorDisplayName}
+        {/* Status / error messages */}
+        {status && (
+          <div className="mb-6 px-4 py-3 border border-amber/30 bg-amber/5">
+            <p className="section-label text-amber">{status}</p>
           </div>
-          <h3 className="story-title">{post.title}</h3>
-          {post.excerpt ? <p className="story-excerpt">{post.excerpt}</p> : null}
-          <div className="auth-actions">
-            <Link className="auth-button secondary" href={`/edit/${post.id}`}>
-              Edit
-            </Link>
-            {!showDeleted ? (
-              <button
-                type="button"
-                className="auth-button"
-                disabled={busyId === post.id}
-                onClick={() => approve(post.id)}
-              >
-                Approve
-              </button>
-            ) : null}
-            {!showDeleted ? (
-              <button
-                type="button"
-                className="auth-button secondary"
-                disabled={busyId === post.id}
-                onClick={() => remove(post.id, false)}
-              >
-                Delete
-              </button>
-            ) : null}
-            <button
-              type="button"
-              className="auth-button secondary"
-              disabled={busyId === post.id}
-              onClick={() => remove(post.id, true)}
-            >
-              Hard Delete
-            </button>
+        )}
+        {error && (
+          <div className="mb-6 px-4 py-3 border border-destructive/30 bg-destructive/5">
+            <p className="section-label text-destructive">{error}</p>
           </div>
-        </article>
-      ))}
+        )}
 
-      {status ? <p className="auth-status">{status}</p> : null}
-      {error ? <p className="auth-error">{error}</p> : null}
-    </section>
+        {/* Loading state */}
+        {loading ? (
+          <div className="py-12 text-center">
+            <p className="section-label text-muted-foreground/50">
+              Loading drafts...
+            </p>
+          </div>
+        ) : posts.length === 0 ? (
+          <div className="py-12 text-center">
+            <p className="section-label text-muted-foreground/50 mb-3">
+              No {showDeleted ? "deleted" : "pending"} drafts
+            </p>
+            <p className="text-muted-foreground/40 text-sm">
+              {showDeleted
+                ? "No drafts have been deleted."
+                : "All submissions have been reviewed."}
+            </p>
+          </div>
+        ) : (
+          <div className="animate-fade-in">
+            {posts.map((post, i) => (
+              <article
+                key={post.id}
+                className={`group py-6 ${i > 0 ? "border-t border-border/30" : ""}`}
+              >
+                <div className="flex items-start gap-6">
+                  <div className="flex-1 min-w-0">
+                    <h2 className="headline-secondary text-foreground mb-2">
+                      {post.title}
+                    </h2>
+                    {post.excerpt && (
+                      <p className="text-muted-foreground text-sm leading-relaxed line-clamp-2 mb-3">
+                        {post.excerpt}
+                      </p>
+                    )}
+                    <div className="byline text-muted-foreground/50 flex items-center gap-1.5 flex-wrap">
+                      <span>By {displayAuthor(post.authorDisplayName)}</span>
+                      {post.publishedAt && (
+                        <>
+                          <span className="text-border/40 mx-0.5">|</span>
+                          <time dateTime={post.publishedAt}>
+                            {formatDate(post.publishedAt)}
+                          </time>
+                        </>
+                      )}
+                    </div>
+                    {post.categories.length > 0 && (
+                      <div className="tags mt-3">
+                        {post.categories.map((cat) => (
+                          <span className="tag" key={cat}>
+                            {cat}
+                          </span>
+                        ))}
+                      </div>
+                    )}
+                  </div>
+                </div>
+
+                {/* Actions */}
+                <div className="flex flex-wrap items-center gap-2 mt-4 pt-4 border-t border-border/20">
+                  <button
+                    type="button"
+                    className="section-label px-3 py-2 text-amber border border-amber/40 hover:bg-amber/10 transition-colors disabled:opacity-50"
+                    disabled={previewLoading === post.id || busyId === post.id}
+                    onClick={() => openPreview(post.id)}
+                  >
+                    {previewLoading === post.id
+                      ? "Loading..."
+                      : "View as Reader"}
+                  </button>
+                  <Link
+                    className="section-label px-3 py-2 text-amber border border-amber/40 hover:bg-amber/10 transition-colors"
+                    href={`/edit/${post.id}`}
+                  >
+                    Edit
+                  </Link>
+                  {!showDeleted && (
+                    <button
+                      type="button"
+                      className="auth-button"
+                      disabled={busyId === post.id}
+                      onClick={() => approve(post.id)}
+                    >
+                      Approve
+                    </button>
+                  )}
+                  <div className="flex-1" />
+                  {!showDeleted && (
+                    <button
+                      type="button"
+                      className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors disabled:opacity-50"
+                      disabled={busyId === post.id}
+                      onClick={() => remove(post.id, false)}
+                    >
+                      Delete
+                    </button>
+                  )}
+                  <button
+                    type="button"
+                    className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors disabled:opacity-50"
+                    disabled={busyId === post.id}
+                    onClick={() => remove(post.id, true)}
+                  >
+                    Hard Delete
+                  </button>
+                </div>
+              </article>
+            ))}
+          </div>
+        )}
+
+      {/* Reader preview modal */}
+      {previewPost && (
+        <ReaderPreview
+          post={previewPost}
+          onClose={() => setPreviewPost(null)}
+        />
+      )}
+    </div>
   );
 }

--- a/ui-nextjs/src/components/admin-users.tsx
+++ b/ui-nextjs/src/components/admin-users.tsx
@@ -21,6 +21,12 @@ function detailMessage(payload: unknown, fallback: string): string {
   return fallback;
 }
 
+const statusTabs: { value: UserStatus; label: string }[] = [
+  { value: "ACTIVE", label: "Active" },
+  { value: "SUSPENDED", label: "Suspended" },
+  { value: "ERASED", label: "Erased" },
+];
+
 export function AdminUsers() {
   const auth = useMemo(() => getAuthState(), []);
   const isAdmin = auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
@@ -60,7 +66,13 @@ export function AdminUsers() {
     void loadUsers("ACTIVE");
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  async function userAction(path: string, method: "PUT" | "DELETE", successMessage: string) {
+  async function userAction(
+    path: string,
+    method: "PUT" | "DELETE",
+    successMessage: string,
+    confirmMessage?: string,
+  ) {
+    if (confirmMessage && !window.confirm(confirmMessage)) return;
     if (!auth.token) return;
     setError(null);
     setNotice(null);
@@ -100,9 +112,6 @@ export function AdminUsers() {
         throw new Error(detailMessage(payload, "Role update failed."));
       }
       setNotice(`Updated ${username} to ${newRole}.`);
-      setUsers((current) =>
-        current.map((user) => (user.username === username ? { ...user, role: newRole } : user)),
-      );
       await loadUsers(status);
     } catch (roleError) {
       setError(roleError instanceof Error ? roleError.message : "Role update failed.");
@@ -111,150 +120,181 @@ export function AdminUsers() {
 
   if (!auth.token || !isAdmin) {
     return (
-      <section className="notice">
-        <h2>Manage Users</h2>
-        <p>Admin access required.</p>
-      </section>
+      <div className="py-12 text-center">
+        <p className="section-label text-muted-foreground">
+          Admin access required.
+        </p>
+      </div>
     );
   }
 
   return (
-    <section className="auth-shell submit-shell">
-      <h2 className="auth-title">Manage Users</h2>
+    <div>
+      {/* Status tabs */}
+      <nav className="flex gap-0 mb-6 border-b border-border/40">
+        {statusTabs.map((tab) => (
+          <button
+            key={tab.value}
+            type="button"
+            onClick={() => loadUsers(tab.value)}
+            className={`section-label px-4 py-3 -mb-px transition-colors ${
+              status === tab.value
+                ? "text-amber border-b-2 border-amber"
+                : "text-muted-foreground hover:text-foreground"
+            }`}
+          >
+            {tab.label}
+            {!loading && status === tab.value && (
+              <span className="ml-2 text-muted-foreground/50">({users.length})</span>
+            )}
+          </button>
+        ))}
+      </nav>
 
-      <div className="auth-actions">
-        <button className="auth-button secondary" type="button" onClick={() => loadUsers("ACTIVE")}>
-          Active
-        </button>
-        <button className="auth-button secondary" type="button" onClick={() => loadUsers("SUSPENDED")}>
-          Suspended
-        </button>
-        <button className="auth-button secondary" type="button" onClick={() => loadUsers("ERASED")}>
-          Erased
-        </button>
-      </div>
+      {/* Status / error messages */}
+      {notice && (
+        <div className="mb-6 px-4 py-3 border border-amber/30 bg-amber/5">
+          <p className="section-label text-amber">{notice}</p>
+        </div>
+      )}
+      {error && (
+        <div className="mb-6 px-4 py-3 border border-destructive/30 bg-destructive/5">
+          <p className="section-label text-destructive">{error}</p>
+        </div>
+      )}
 
-      {loading ? <p>Loading users...</p> : null}
-      {!loading && users.length === 0 ? <p>No {status.toLowerCase()} users.</p> : null}
+      {loading ? (
+        <div className="py-12 text-center">
+          <p className="section-label text-muted-foreground/50">Loading users...</p>
+        </div>
+      ) : users.length === 0 ? (
+        <div className="py-12 text-center">
+          <p className="section-label text-muted-foreground/50 mb-3">
+            No {status.toLowerCase()} users
+          </p>
+        </div>
+      ) : (
+        <div className="animate-fade-in">
+          {users.map((user, i) => (
+            <div
+              key={user.id}
+              className={`py-5 ${i > 0 ? "border-t border-border/30" : ""}`}
+            >
+              <div className="flex items-start justify-between gap-4 flex-wrap">
+                <div className="min-w-0">
+                  <h3 className="headline-brief text-foreground mb-1">
+                    {user.displayName}
+                  </h3>
+                  <div className="byline text-muted-foreground/50 flex items-center gap-1.5 flex-wrap">
+                    <span>{user.username}</span>
+                    <span className="text-border/40 mx-0.5">|</span>
+                    <span className={user.role === "SUPER_ADMIN" ? "text-amber" : ""}>
+                      {user.role}
+                    </span>
+                  </div>
+                </div>
 
-      {!loading && users.length > 0 ? (
-        <table className="factoid-table" role="grid">
-          <thead>
-            <tr>
-              <th>Username</th>
-              <th>Display Name</th>
-              <th>Role</th>
-              <th>Actions</th>
-            </tr>
-          </thead>
-          <tbody>
-            {users.map((user) => (
-              <tr key={user.id}>
-                <td>{user.username}</td>
-                <td>{user.displayName}</td>
-                <td>{user.role}</td>
-                <td>
-                  <div className="auth-actions">
-                    {status === "ACTIVE" ? (
-                      <>
-                        <button
-                          className="auth-button secondary"
-                          type="button"
-                          onClick={() =>
-                            userAction(
-                              `/api/admin/users/${encodeURIComponent(user.username)}/suspend`,
-                              "PUT",
-                              `Suspended ${user.username}.`,
-                            )
-                          }
-                        >
-                          Suspend
-                        </button>
-                        <button
-                          className="auth-button secondary"
-                          type="button"
-                          onClick={() =>
-                            userAction(
-                              `/api/admin/users/${encodeURIComponent(user.username)}`,
-                              "DELETE",
-                              `Erased ${user.username}.`,
-                            )
-                          }
-                        >
-                          Erase
-                        </button>
-                        <select
-                          className="auth-input"
-                          defaultValue=""
-                          onChange={(event) => {
-                            const value = event.target.value as Role | "";
-                            if (!value) return;
-                            void changeRole(user.username, value);
-                            event.currentTarget.value = "";
-                          }}
-                        >
-                          <option value="">Change role...</option>
-                          <option value="USER">USER</option>
-                          <option value="ADMIN">ADMIN</option>
-                          <option value="SUPER_ADMIN">SUPER_ADMIN</option>
-                        </select>
-                      </>
-                    ) : null}
-                    {status === "SUSPENDED" ? (
-                      <>
-                        <button
-                          className="auth-button secondary"
-                          type="button"
-                          onClick={() =>
-                            userAction(
-                              `/api/admin/users/${encodeURIComponent(user.username)}/unsuspend`,
-                              "PUT",
-                              `Unsuspended ${user.username}.`,
-                            )
-                          }
-                        >
-                          Unsuspend
-                        </button>
-                        <button
-                          className="auth-button secondary"
-                          type="button"
-                          onClick={() =>
-                            userAction(
-                              `/api/admin/users/${encodeURIComponent(user.username)}`,
-                              "DELETE",
-                              `Erased ${user.username}.`,
-                            )
-                          }
-                        >
-                          Erase
-                        </button>
-                      </>
-                    ) : null}
-                    {status === "ERASED" ? (
+                <div className="flex items-center gap-2 flex-wrap">
+                  {status === "ACTIVE" && (
+                    <>
+                      <select
+                        className="section-label px-3 py-2 bg-transparent border border-border/40 text-muted-foreground hover:border-amber/40 transition-colors appearance-none cursor-pointer"
+                        defaultValue=""
+                        onChange={(event) => {
+                          const value = event.target.value as Role | "";
+                          if (!value) return;
+                          void changeRole(user.username, value);
+                          event.currentTarget.value = "";
+                        }}
+                      >
+                        <option value="">Role...</option>
+                        <option value="USER">User</option>
+                        <option value="ADMIN">Admin</option>
+                        <option value="SUPER_ADMIN">Super Admin</option>
+                      </select>
                       <button
-                        className="auth-button secondary"
+                        className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-amber hover:border-amber/40 transition-colors"
                         type="button"
                         onClick={() =>
                           userAction(
-                            `/api/admin/users/${encodeURIComponent(user.username)}/purge`,
-                            "DELETE",
-                            `Purged content for ${user.username}.`,
+                            `/api/admin/users/${encodeURIComponent(user.username)}/suspend`,
+                            "PUT",
+                            `Suspended ${user.username}.`,
+                            `Suspend ${user.username}?`,
                           )
                         }
                       >
-                        Purge Content
+                        Suspend
                       </button>
-                    ) : null}
-                  </div>
-                </td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
-      ) : null}
-
-      {notice ? <p className="auth-status">{notice}</p> : null}
-      {error ? <p className="auth-error">{error}</p> : null}
-    </section>
+                      <button
+                        className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors"
+                        type="button"
+                        onClick={() =>
+                          userAction(
+                            `/api/admin/users/${encodeURIComponent(user.username)}`,
+                            "DELETE",
+                            `Erased ${user.username}.`,
+                            `Erase ${user.username}? This will mark the account for deletion.`,
+                          )
+                        }
+                      >
+                        Erase
+                      </button>
+                    </>
+                  )}
+                  {status === "SUSPENDED" && (
+                    <>
+                      <button
+                        className="section-label px-3 py-2 text-amber border border-amber/40 hover:bg-amber/10 transition-colors"
+                        type="button"
+                        onClick={() =>
+                          userAction(
+                            `/api/admin/users/${encodeURIComponent(user.username)}/unsuspend`,
+                            "PUT",
+                            `Unsuspended ${user.username}.`,
+                          )
+                        }
+                      >
+                        Unsuspend
+                      </button>
+                      <button
+                        className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors"
+                        type="button"
+                        onClick={() =>
+                          userAction(
+                            `/api/admin/users/${encodeURIComponent(user.username)}`,
+                            "DELETE",
+                            `Erased ${user.username}.`,
+                            `Erase ${user.username}? This will mark the account for deletion.`,
+                          )
+                        }
+                      >
+                        Erase
+                      </button>
+                    </>
+                  )}
+                  {status === "ERASED" && (
+                    <button
+                      className="section-label px-3 py-2 text-muted-foreground border border-border/40 hover:text-destructive hover:border-destructive/40 transition-colors"
+                      type="button"
+                      onClick={() =>
+                        userAction(
+                          `/api/admin/users/${encodeURIComponent(user.username)}/purge`,
+                          "DELETE",
+                          `Purged content for ${user.username}.`,
+                          `Permanently purge all content from ${user.username}? This cannot be undone.`,
+                        )
+                      }
+                    >
+                      Purge Content
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
   );
 }

--- a/ui-nextjs/src/components/auth-nav.tsx
+++ b/ui-nextjs/src/components/auth-nav.tsx
@@ -118,26 +118,12 @@ export function AuthNav({ allowAnonymousSubmission = false }: AuthNavProps) {
         {auth.principal.displayName}
       </Link>
       {isAdmin && (
-        <>
-          <Link
-            className="section-label text-muted-foreground hover:text-amber transition-colors duration-200 px-2"
-            href="/admin/pending"
-          >
-            Pending
-          </Link>
-          <Link
-            className="section-label text-muted-foreground hover:text-amber transition-colors duration-200 px-2"
-            href="/admin/users"
-          >
-            Users
-          </Link>
-          <Link
-            className="section-label text-muted-foreground hover:text-amber transition-colors duration-200 px-2"
-            href="/admin/categories"
-          >
-            Categories
-          </Link>
-        </>
+        <Link
+          className="section-label text-muted-foreground hover:text-amber transition-colors duration-200 px-2"
+          href="/admin"
+        >
+          Admin
+        </Link>
       )}
       <a
         href="/logout"


### PR DESCRIPTION
- New admin dashboard at /admin with stats grid (pending drafts, published posts, active/suspended users), categories list with post counts, top tags, and system info panel
- Shared admin layout with tab navigation (Dashboard, Pending Drafts, Users, Categories) replacing per-page headers
- Redesigned pending drafts: View as Reader modal preview, confirm dialogs on delete/hard delete, Active/Deleted tab switcher, "Unattributed" instead of "UNKNOWN" for missing authors
- Redesigned users: card layout with status tabs, confirm dialogs on destructive actions, styled role dropdown
- Redesigned categories: inline creation form, parent/child grouping, confirm on delete with category name
- Consolidated header nav: single "Admin" link replaces three separate links (Pending, Users, Categories)
- New API route handlers for /api/features, /api/taxonomy, and GET /api/posts to support client-side dashboard fetches
- Fixed dashboard category counts using lowercase key lookup to match taxonomy backend

fixes #332 