### PR TITLE
Add server-side refresh tokens and httpOnly cookie auth

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,6 +77,7 @@ services:
       - SLACK_ENABLED=${SLACK_ENABLED:-false}
       - JWT_SECRET=${JWT_SECRET:-change-me-in-production}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000,http://localhost:3001,http://localhost:3003}
+      - STREAMPACK_COOKIE_SECURE=false
       - MAIL_HOST=mailpit
       - MAIL_PORT=1025
     depends_on:

--- a/lib-blog/src/main/kotlin/com/enigmastation/streampack/blog/model/LoginResponse.kt
+++ b/lib-blog/src/main/kotlin/com/enigmastation/streampack/blog/model/LoginResponse.kt
@@ -2,6 +2,11 @@
 package com.enigmastation.streampack.blog.model
 
 import com.enigmastation.streampack.core.model.UserPrincipal
+import com.fasterxml.jackson.annotation.JsonIgnore
 
 /** Successful authentication result with JWT and resolved identity */
-data class LoginResponse(val token: String, val principal: UserPrincipal)
+data class LoginResponse(
+    val token: String,
+    val principal: UserPrincipal,
+    @JsonIgnore val refreshToken: String? = null,
+)

--- a/lib-blog/src/main/kotlin/com/enigmastation/streampack/blog/service/UserConvergenceService.kt
+++ b/lib-blog/src/main/kotlin/com/enigmastation/streampack/blog/service/UserConvergenceService.kt
@@ -7,6 +7,7 @@ import com.enigmastation.streampack.core.model.Protocol
 import com.enigmastation.streampack.core.repository.ServiceBindingRepository
 import com.enigmastation.streampack.core.repository.UserRepository
 import com.enigmastation.streampack.core.service.JwtService
+import com.enigmastation.streampack.core.service.RefreshTokenService
 import com.enigmastation.streampack.core.service.UserRegistrationService
 import java.time.Instant
 import org.slf4j.LoggerFactory
@@ -25,6 +26,7 @@ class UserConvergenceService(
     private val serviceBindingRepository: ServiceBindingRepository,
     private val userRegistrationService: UserRegistrationService,
     private val jwtService: JwtService,
+    private val refreshTokenService: RefreshTokenService,
     blogProperties: BlogProperties,
 ) {
     private val logger = LoggerFactory.getLogger(UserConvergenceService::class.java)
@@ -78,7 +80,8 @@ class UserConvergenceService(
 
         val principal = user.toUserPrincipal()
         val token = jwtService.generateToken(principal)
-        return LoginResponse(token, principal)
+        val refreshToken = refreshTokenService.issueToken(user.id)
+        return LoginResponse(token, principal, refreshToken)
     }
 
     /** Derives a unique username from the email prefix, appending a numeric suffix on collision */

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/config/StreampackProperties.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/config/StreampackProperties.kt
@@ -12,6 +12,8 @@ data class StreampackProperties(
     val token: TokenProperties = TokenProperties(),
     val mail: MailProperties = MailProperties(),
     val otp: OtpProperties = OtpProperties(),
+    val refreshToken: RefreshTokenProperties = RefreshTokenProperties(),
+    val cookie: CookieProperties = CookieProperties(),
     val maxHops: Int = 3,
 ) {
     data class JwtProperties(val secret: String = "", val expirationHours: Long = 24)
@@ -21,4 +23,8 @@ data class StreampackProperties(
     data class MailProperties(val from: String = "noreply@bytecode.news")
 
     data class OtpProperties(val maxActiveCodes: Int = 3, val expirationMinutes: Long = 10)
+
+    data class RefreshTokenProperties(val days: Long = 30)
+
+    data class CookieProperties(val secure: Boolean = true)
 }

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/entity/RefreshToken.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/entity/RefreshToken.kt
@@ -1,0 +1,21 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.core.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import java.time.Instant
+import java.util.UUID
+import org.hibernate.annotations.UuidGenerator
+
+/** A long-lived opaque token used to obtain new JWTs after the access token expires */
+@Entity
+@Table(name = "refresh_tokens")
+data class RefreshToken(
+    @Id @UuidGenerator(style = UuidGenerator.Style.VERSION_7) val id: UUID = UUID(0, 0),
+    @Column(nullable = false) val userId: UUID = UUID(0, 0),
+    @Column(nullable = false) val tokenHash: String = "",
+    @Column(nullable = false) val expiresAt: Instant = Instant.now(),
+    @Column(nullable = false) val createdAt: Instant = Instant.now(),
+)

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/repository/RefreshTokenRepository.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/repository/RefreshTokenRepository.kt
@@ -1,0 +1,25 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.core.repository
+
+import com.enigmastation.streampack.core.entity.RefreshToken
+import java.time.Instant
+import java.util.UUID
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+
+/** Persistence for long-lived refresh tokens */
+interface RefreshTokenRepository : JpaRepository<RefreshToken, UUID> {
+
+    fun findByTokenHash(tokenHash: String): RefreshToken?
+
+    /** Removes all refresh tokens that have expired */
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.expiresAt < :cutoff")
+    fun deleteExpired(cutoff: Instant): Int
+
+    /** Removes all refresh tokens for a given user (for logout or account erasure) */
+    @Modifying
+    @Query("DELETE FROM RefreshToken r WHERE r.userId = :userId")
+    fun deleteByUserId(userId: UUID): Int
+}

--- a/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/RefreshTokenService.kt
+++ b/lib-core/src/main/kotlin/com/enigmastation/streampack/core/service/RefreshTokenService.kt
@@ -1,0 +1,97 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.core.service
+
+import com.enigmastation.streampack.core.config.StreampackProperties
+import com.enigmastation.streampack.core.entity.RefreshToken
+import com.enigmastation.streampack.core.repository.RefreshTokenRepository
+import java.security.MessageDigest
+import java.security.SecureRandom
+import java.time.Duration
+import java.time.Instant
+import java.util.Base64
+import java.util.UUID
+import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/** Manages opaque refresh tokens for persistent session authentication */
+@Service
+class RefreshTokenService(
+    private val refreshTokenRepository: RefreshTokenRepository,
+    properties: StreampackProperties,
+) {
+    private val logger = LoggerFactory.getLogger(RefreshTokenService::class.java)
+    private val random = SecureRandom()
+    private val ttlDays = properties.refreshToken.days
+
+    /** Issues a new refresh token for the given user, returning the raw (unhashed) token */
+    @Transactional
+    fun issueToken(userId: UUID): String {
+        cleanupExpired()
+        val rawToken = generateOpaqueToken()
+        val hash = sha256(rawToken)
+        val entity =
+            RefreshToken(
+                userId = userId,
+                tokenHash = hash,
+                expiresAt = Instant.now().plus(Duration.ofDays(ttlDays)),
+            )
+        refreshTokenRepository.saveAndFlush(entity)
+        return rawToken
+    }
+
+    /** Validates and rotates a refresh token, returning the userId and a new raw token */
+    @Transactional
+    fun rotateToken(rawToken: String): Pair<UUID, String>? {
+        val hash = sha256(rawToken)
+        val existing = refreshTokenRepository.findByTokenHash(hash) ?: return null
+        if (Instant.now().isAfter(existing.expiresAt)) {
+            refreshTokenRepository.delete(existing)
+            return null
+        }
+        refreshTokenRepository.delete(existing)
+        val newRaw = generateOpaqueToken()
+        val newHash = sha256(newRaw)
+        val newEntity =
+            RefreshToken(
+                userId = existing.userId,
+                tokenHash = newHash,
+                expiresAt = Instant.now().plus(Duration.ofDays(ttlDays)),
+            )
+        refreshTokenRepository.saveAndFlush(newEntity)
+        return existing.userId to newRaw
+    }
+
+    /** Revokes all refresh tokens for a user (for logout or account erasure) */
+    @Transactional
+    fun revokeAllForUser(userId: UUID): Int {
+        val deleted = refreshTokenRepository.deleteByUserId(userId)
+        if (deleted > 0) {
+            logger.debug("Revoked {} refresh tokens for user {}", deleted, userId)
+        }
+        return deleted
+    }
+
+    /** Opportunistic cleanup of expired refresh tokens */
+    @Transactional
+    fun cleanupExpired(now: Instant = Instant.now()): Int {
+        val deleted = refreshTokenRepository.deleteExpired(now)
+        if (deleted > 0) {
+            logger.debug("Deleted {} expired refresh tokens", deleted)
+        }
+        return deleted
+    }
+
+    private fun generateOpaqueToken(): String {
+        val bytes = ByteArray(32)
+        random.nextBytes(bytes)
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
+    }
+
+    companion object {
+        fun sha256(input: String): String {
+            val digest = MessageDigest.getInstance("SHA-256")
+            return digest.digest(input.toByteArray()).joinToString("") { "%02x".format(it) }
+        }
+    }
+}

--- a/lib-core/src/main/resources/db/migration/V33__create_refresh_tokens.sql
+++ b/lib-core/src/main/resources/db/migration/V33__create_refresh_tokens.sql
@@ -1,0 +1,11 @@
+CREATE TABLE refresh_tokens (
+    id          UUID PRIMARY KEY,
+    user_id     UUID NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    token_hash  VARCHAR(64) NOT NULL,
+    expires_at  TIMESTAMP WITH TIME ZONE NOT NULL,
+    created_at  TIMESTAMP WITH TIME ZONE NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX idx_refresh_tokens_token_hash ON refresh_tokens(token_hash);
+CREATE INDEX idx_refresh_tokens_user_id ON refresh_tokens(user_id);
+CREATE INDEX idx_refresh_tokens_expires_at ON refresh_tokens(expires_at);

--- a/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/RefreshTokenServiceTests.kt
+++ b/lib-core/src/test/kotlin/com/enigmastation/streampack/core/service/RefreshTokenServiceTests.kt
@@ -1,0 +1,119 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.core.service
+
+import com.enigmastation.streampack.core.model.Protocol
+import com.enigmastation.streampack.core.repository.RefreshTokenRepository
+import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Assertions.assertNull
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.transaction.annotation.Transactional
+
+@SpringBootTest
+@Transactional
+class RefreshTokenServiceTests {
+
+    @Autowired lateinit var refreshTokenService: RefreshTokenService
+    @Autowired lateinit var refreshTokenRepository: RefreshTokenRepository
+    @Autowired lateinit var userRegistrationService: UserRegistrationService
+
+    private var testUserId: UUID = UUID(0, 0)
+
+    @BeforeEach
+    fun setUp() {
+        val principal =
+            userRegistrationService.register(
+                username = "refreshtest",
+                email = "refreshtest@example.com",
+                displayName = "Refresh Test",
+                protocol = Protocol.HTTP,
+                serviceId = "test-service",
+                externalIdentifier = "refreshtest@example.com",
+            )
+        testUserId = principal.id
+    }
+
+    @Test
+    fun `issueToken creates a hashed record in the database`() {
+        val rawToken = refreshTokenService.issueToken(testUserId)
+
+        assertNotNull(rawToken)
+        assertTrue(rawToken.isNotBlank())
+
+        val hash = RefreshTokenService.sha256(rawToken)
+        val stored = refreshTokenRepository.findByTokenHash(hash)
+        assertNotNull(stored)
+        assertEquals(testUserId, stored!!.userId)
+    }
+
+    @Test
+    fun `stored hash does not equal the raw token`() {
+        val rawToken = refreshTokenService.issueToken(testUserId)
+        val hash = RefreshTokenService.sha256(rawToken)
+
+        assertNotEquals(rawToken, hash)
+    }
+
+    @Test
+    fun `rotateToken invalidates old token and issues new one`() {
+        val rawToken = refreshTokenService.issueToken(testUserId)
+
+        val result = refreshTokenService.rotateToken(rawToken)
+
+        assertNotNull(result)
+        val (userId, newRawToken) = result!!
+        assertEquals(testUserId, userId)
+        assertNotEquals(rawToken, newRawToken)
+
+        assertNull(refreshTokenRepository.findByTokenHash(RefreshTokenService.sha256(rawToken)))
+        assertNotNull(
+            refreshTokenRepository.findByTokenHash(RefreshTokenService.sha256(newRawToken))
+        )
+    }
+
+    @Test
+    fun `rotateToken returns null for unknown token`() {
+        val result = refreshTokenService.rotateToken("nonexistent-token")
+
+        assertNull(result)
+    }
+
+    @Test
+    fun `rotateToken returns null for already-used token`() {
+        val rawToken = refreshTokenService.issueToken(testUserId)
+
+        val firstRotation = refreshTokenService.rotateToken(rawToken)
+        assertNotNull(firstRotation)
+
+        val secondRotation = refreshTokenService.rotateToken(rawToken)
+        assertNull(secondRotation)
+    }
+
+    @Test
+    fun `revokeAllForUser deletes all tokens for user`() {
+        refreshTokenService.issueToken(testUserId)
+        refreshTokenService.issueToken(testUserId)
+        refreshTokenService.issueToken(testUserId)
+
+        val deleted = refreshTokenService.revokeAllForUser(testUserId)
+
+        assertEquals(3, deleted)
+        assertTrue(refreshTokenRepository.findAll().none { it.userId == testUserId })
+    }
+
+    @Test
+    fun `cleanupExpired removes only expired rows`() {
+        refreshTokenService.issueToken(testUserId)
+
+        val deleted = refreshTokenService.cleanupExpired()
+
+        assertEquals(0, deleted)
+        assertTrue(refreshTokenRepository.findAll().any { it.userId == testUserId })
+    }
+}

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/AuthController.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/AuthController.kt
@@ -7,14 +7,16 @@ import com.enigmastation.streampack.blog.model.ExportUserDataRequest
 import com.enigmastation.streampack.blog.model.LoginResponse
 import com.enigmastation.streampack.blog.model.OtpRequest
 import com.enigmastation.streampack.blog.model.OtpVerifyRequest
-import com.enigmastation.streampack.blog.model.TokenRefreshRequest
+import com.enigmastation.streampack.blog.service.CookieService
 import com.enigmastation.streampack.core.integration.EventGateway
 import com.enigmastation.streampack.core.model.EditProfileRequest
 import com.enigmastation.streampack.core.model.OperationResult
 import com.enigmastation.streampack.core.model.Protocol
 import com.enigmastation.streampack.core.model.Provenance
 import com.enigmastation.streampack.core.model.UserPrincipal
+import com.enigmastation.streampack.core.repository.UserRepository
 import com.enigmastation.streampack.core.service.JwtService
+import com.enigmastation.streampack.core.service.RefreshTokenService
 import io.swagger.v3.oas.annotations.Operation
 import io.swagger.v3.oas.annotations.media.Content
 import io.swagger.v3.oas.annotations.media.Schema
@@ -22,6 +24,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse
 import io.swagger.v3.oas.annotations.security.SecurityRequirement
 import io.swagger.v3.oas.annotations.tags.Tag
 import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ProblemDetail
@@ -42,6 +45,9 @@ import org.springframework.web.bind.annotation.RestController
 class AuthController(
     private val eventGateway: EventGateway,
     private val jwtService: JwtService,
+    private val refreshTokenService: RefreshTokenService,
+    private val cookieService: CookieService,
+    private val userRepository: UserRepository,
     blogProperties: BlogProperties,
 ) {
     private val serviceId = blogProperties.serviceId
@@ -69,20 +75,41 @@ class AuthController(
         content = [Content(schema = Schema(implementation = ProblemDetail::class))],
     )
     @PostMapping("/otp/verify", produces = ["application/json"], consumes = ["application/json"])
-    fun verifyOtp(@RequestBody request: OtpVerifyRequest): ResponseEntity<*> {
-        return dispatch(request, "auth/otp/verify") { result ->
-            mapError(result, HttpStatus.UNAUTHORIZED)
+    fun verifyOtp(
+        @RequestBody request: OtpVerifyRequest,
+        httpResponse: HttpServletResponse,
+    ): ResponseEntity<*> {
+        val entity =
+            dispatch(request, "auth/otp/verify") { result ->
+                mapError(result, HttpStatus.UNAUTHORIZED)
+            }
+        if (entity.statusCode == HttpStatus.OK && entity.body is LoginResponse) {
+            val loginResponse = entity.body as LoginResponse
+            httpResponse.addCookie(cookieService.createAccessTokenCookie(loginResponse.token))
+            loginResponse.refreshToken?.let {
+                httpResponse.addCookie(cookieService.createRefreshTokenCookie(it))
+            }
         }
+        return entity
     }
 
     @Operation(summary = "Log out the current session")
     @ApiResponse(responseCode = "204", description = "Logged out")
     @PostMapping("/logout")
-    fun logout(): ResponseEntity<Void> {
+    fun logout(
+        httpRequest: HttpServletRequest,
+        httpResponse: HttpServletResponse,
+    ): ResponseEntity<Void> {
+        val user = resolveUser(httpRequest)
+        if (user != null) {
+            refreshTokenService.revokeAllForUser(user.id)
+        }
+        httpResponse.addCookie(cookieService.clearAccessTokenCookie())
+        httpResponse.addCookie(cookieService.clearRefreshTokenCookie())
         return ResponseEntity.noContent().build()
     }
 
-    @Operation(summary = "Refresh an expired JWT token")
+    @Operation(summary = "Refresh an expired JWT token using a refresh token cookie")
     @ApiResponse(
         responseCode = "200",
         description = "Token refreshed",
@@ -93,11 +120,24 @@ class AuthController(
         description = "Invalid or expired refresh token",
         content = [Content(schema = Schema(implementation = ProblemDetail::class))],
     )
-    @PostMapping("/refresh", produces = ["application/json"], consumes = ["application/json"])
-    fun refresh(@RequestBody request: TokenRefreshRequest): ResponseEntity<*> {
-        return dispatch(request, "auth/refresh") { result ->
-            mapError(result, HttpStatus.UNAUTHORIZED)
-        }
+    @PostMapping("/refresh", produces = ["application/json"])
+    fun refresh(
+        httpRequest: HttpServletRequest,
+        httpResponse: HttpServletResponse,
+    ): ResponseEntity<*> {
+        val rawRefreshToken =
+            extractRefreshToken(httpRequest) ?: return unauthorized("Missing refresh token")
+        val (userId, newRawToken) =
+            refreshTokenService.rotateToken(rawRefreshToken)
+                ?: return unauthorized("Invalid or expired refresh token")
+        val user =
+            userRepository.findActiveById(userId)
+                ?: return unauthorized("Invalid or expired refresh token")
+        val principal = user.toUserPrincipal()
+        val newJwt = jwtService.generateToken(principal)
+        httpResponse.addCookie(cookieService.createAccessTokenCookie(newJwt))
+        httpResponse.addCookie(cookieService.createRefreshTokenCookie(newRawToken))
+        return ResponseEntity.ok(LoginResponse(newJwt, principal))
     }
 
     @Operation(summary = "Erase the authenticated user's account")
@@ -169,12 +209,23 @@ class AuthController(
         }
     }
 
-    /** Extracts and validates the Bearer token from the Authorization header */
+    /** Extracts and validates the JWT from cookies first, then the Authorization header */
     private fun resolveUser(request: HttpServletRequest): UserPrincipal? {
+        val cookieToken =
+            request.cookies?.find { it.name == CookieService.ACCESS_TOKEN_COOKIE }?.value
+        if (cookieToken != null) {
+            val principal = jwtService.validateToken(cookieToken)
+            if (principal != null) return principal
+        }
         val header = request.getHeader("Authorization") ?: return null
         if (!header.startsWith("Bearer ")) return null
         val token = header.substring(7)
         return jwtService.validateToken(token)
+    }
+
+    /** Extracts the refresh token from the cookie */
+    private fun extractRefreshToken(request: HttpServletRequest): String? {
+        return request.cookies?.find { it.name == CookieService.REFRESH_TOKEN_COOKIE }?.value
     }
 
     /** Sends a payload through the event system and maps the result to an HTTP response */

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/OidcAuthenticationSuccessHandler.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/OidcAuthenticationSuccessHandler.kt
@@ -1,6 +1,7 @@
 /* Joseph B. Ottinger (C)2026 */
 package com.enigmastation.streampack.blog.controller
 
+import com.enigmastation.streampack.blog.service.CookieService
 import com.enigmastation.streampack.blog.service.UserConvergenceService
 import com.enigmastation.streampack.core.config.StreampackProperties
 import jakarta.servlet.http.HttpServletRequest
@@ -14,11 +15,12 @@ import org.springframework.stereotype.Component
 
 /**
  * Handles successful OIDC/OAuth2 authentication by converging the external identity to a local user
- * and redirecting to the frontend with a JWT in the URL fragment.
+ * and redirecting to the frontend with authentication cookies.
  */
 @Component
 class OidcAuthenticationSuccessHandler(
     private val userConvergenceService: UserConvergenceService,
+    private val cookieService: CookieService,
     properties: StreampackProperties,
 ) : AuthenticationSuccessHandler {
     private val logger = LoggerFactory.getLogger(OidcAuthenticationSuccessHandler::class.java)
@@ -34,8 +36,11 @@ class OidcAuthenticationSuccessHandler(
         logger.info("OIDC authentication succeeded for {}", email)
         val loginResponse = userConvergenceService.converge(email, displayName)
 
-        /* Deliver JWT via URL fragment so it is not sent to the server in subsequent requests */
-        response.sendRedirect("$frontendUrl/auth/callback#token=${loginResponse.token}")
+        response.addCookie(cookieService.createAccessTokenCookie(loginResponse.token))
+        loginResponse.refreshToken?.let {
+            response.addCookie(cookieService.createRefreshTokenCookie(it))
+        }
+        response.sendRedirect("$frontendUrl/auth/callback")
     }
 
     /** Extracts email and display name from either an OIDC or plain OAuth2 principal */

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/WebSecurityConfiguration.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/controller/WebSecurityConfiguration.kt
@@ -34,8 +34,10 @@ class WebSecurityConfiguration(
         val config = CorsConfiguration()
         config.allowedOrigins = corsOrigins.split(",").map { it.trim() }
         config.allowedMethods = listOf("GET", "POST", "PUT", "DELETE", "OPTIONS")
-        config.allowedHeaders = listOf("Authorization", "Content-Type", "Accept", "Accept-Version")
-        config.exposedHeaders = listOf("Content-Version", "Accept-Version")
+        config.allowedHeaders =
+            listOf("Authorization", "Content-Type", "Accept", "Accept-Version", "Cookie")
+        config.exposedHeaders = listOf("Content-Version", "Accept-Version", "Set-Cookie")
+        config.allowCredentials = true
         config.maxAge = 3600L
         val source = UrlBasedCorsConfigurationSource()
         source.registerCorsConfiguration("/**", config)

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/model/TokenRefreshRequest.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/model/TokenRefreshRequest.kt
@@ -1,5 +1,5 @@
 /* Joseph B. Ottinger (C)2026 */
 package com.enigmastation.streampack.blog.model
 
-/** Request to issue a fresh JWT from an existing valid token */
-data class TokenRefreshRequest(val token: String)
+/** Request to issue a fresh JWT from an existing valid token or a validated user ID */
+data class TokenRefreshRequest(val token: String = "", val userId: java.util.UUID? = null)

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/operation/TokenRefreshOperation.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/operation/TokenRefreshOperation.kt
@@ -10,7 +10,7 @@ import com.enigmastation.streampack.core.service.Operation
 import org.springframework.messaging.Message
 import org.springframework.stereotype.Component
 
-/** Issues a fresh JWT from a valid existing token */
+/** Issues a fresh JWT from a valid existing token or a validated user ID */
 @Component
 class TokenRefreshOperation(
     private val jwtService: JwtService,
@@ -23,11 +23,19 @@ class TokenRefreshOperation(
     override fun execute(message: Message<*>): OperationResult {
         val request = message.payload as TokenRefreshRequest
 
+        if (request.userId != null) {
+            val user =
+                userRepository.findActiveById(request.userId)
+                    ?: return OperationResult.Error("Invalid or expired token")
+            val principal = user.toUserPrincipal()
+            val newToken = jwtService.generateToken(principal)
+            return OperationResult.Success(LoginResponse(newToken, principal))
+        }
+
         val principal =
             jwtService.validateToken(request.token)
                 ?: return OperationResult.Error("Invalid or expired token")
 
-        // Verify the user still exists and is active
         userRepository.findActiveById(principal.id)
             ?: return OperationResult.Error("Invalid or expired token")
 

--- a/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/service/CookieService.kt
+++ b/service-blog/src/main/kotlin/com/enigmastation/streampack/blog/service/CookieService.kt
@@ -1,0 +1,59 @@
+/* Joseph B. Ottinger (C)2026 */
+package com.enigmastation.streampack.blog.service
+
+import com.enigmastation.streampack.core.config.StreampackProperties
+import jakarta.servlet.http.Cookie
+import org.springframework.stereotype.Service
+
+/** Centralizes creation and clearing of authentication cookies */
+@Service
+class CookieService(properties: StreampackProperties) {
+    private val secure = properties.cookie.secure
+    private val jwtMaxAge = (properties.jwt.expirationHours * 3600).toInt()
+    private val refreshMaxAge = (properties.refreshToken.days * 86400).toInt()
+
+    /** Creates an httpOnly cookie carrying the JWT access token */
+    fun createAccessTokenCookie(jwt: String): Cookie =
+        Cookie(ACCESS_TOKEN_COOKIE, jwt).apply {
+            isHttpOnly = true
+            this.secure = this@CookieService.secure
+            path = "/"
+            maxAge = jwtMaxAge
+            setAttribute("SameSite", "Strict")
+        }
+
+    /** Creates an httpOnly cookie carrying the refresh token */
+    fun createRefreshTokenCookie(refreshToken: String): Cookie =
+        Cookie(REFRESH_TOKEN_COOKIE, refreshToken).apply {
+            isHttpOnly = true
+            this.secure = this@CookieService.secure
+            path = "/"
+            maxAge = refreshMaxAge
+            setAttribute("SameSite", "Strict")
+        }
+
+    /** Creates an expired access token cookie to clear it from the browser */
+    fun clearAccessTokenCookie(): Cookie =
+        Cookie(ACCESS_TOKEN_COOKIE, "").apply {
+            isHttpOnly = true
+            this.secure = this@CookieService.secure
+            path = "/"
+            maxAge = 0
+            setAttribute("SameSite", "Strict")
+        }
+
+    /** Creates an expired refresh token cookie to clear it from the browser */
+    fun clearRefreshTokenCookie(): Cookie =
+        Cookie(REFRESH_TOKEN_COOKIE, "").apply {
+            isHttpOnly = true
+            this.secure = this@CookieService.secure
+            path = "/"
+            maxAge = 0
+            setAttribute("SameSite", "Strict")
+        }
+
+    companion object {
+        const val ACCESS_TOKEN_COOKIE = "access_token"
+        const val REFRESH_TOKEN_COOKIE = "refresh_token"
+    }
+}

--- a/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/AuthControllerTests.kt
+++ b/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/AuthControllerTests.kt
@@ -1,17 +1,21 @@
 /* Joseph B. Ottinger (C)2026 */
 package com.enigmastation.streampack.blog.controller
 
+import com.enigmastation.streampack.blog.service.CookieService
 import com.enigmastation.streampack.core.entity.OneTimeCode
 import com.enigmastation.streampack.core.entity.User
 import com.enigmastation.streampack.core.model.Protocol
 import com.enigmastation.streampack.core.repository.OneTimeCodeRepository
+import com.enigmastation.streampack.core.repository.RefreshTokenRepository
 import com.enigmastation.streampack.core.repository.UserRepository
 import com.enigmastation.streampack.core.service.JwtService
+import com.enigmastation.streampack.core.service.RefreshTokenService
 import com.enigmastation.streampack.core.service.UserRegistrationService
 import com.enigmastation.streampack.test.TestChannelConfiguration
 import com.icegreen.greenmail.configuration.GreenMailConfiguration
 import com.icegreen.greenmail.junit5.GreenMailExtension
 import com.icegreen.greenmail.util.ServerSetupTest
+import jakarta.servlet.http.Cookie
 import java.time.Instant
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
@@ -52,6 +56,8 @@ class AuthControllerTests {
     @Autowired lateinit var userRepository: UserRepository
     @Autowired lateinit var oneTimeCodeRepository: OneTimeCodeRepository
     @Autowired lateinit var jwtService: JwtService
+    @Autowired lateinit var refreshTokenService: RefreshTokenService
+    @Autowired lateinit var refreshTokenRepository: RefreshTokenRepository
 
     private lateinit var testUser: User
     private lateinit var testUserToken: String
@@ -143,6 +149,24 @@ class AuthControllerTests {
     }
 
     @Test
+    fun `valid otp verify sets httpOnly cookies`() {
+        seedCode("test@example.com", "111111")
+
+        mockMvc
+            .post("/auth/otp/verify") {
+                contentType = MediaType.APPLICATION_JSON
+                content = """{"email":"test@example.com","code":"111111"}"""
+            }
+            .andExpect {
+                status { isOk() }
+                cookie { exists(CookieService.ACCESS_TOKEN_COOKIE) }
+                cookie { exists(CookieService.REFRESH_TOKEN_COOKIE) }
+                cookie { httpOnly(CookieService.ACCESS_TOKEN_COOKIE, true) }
+                cookie { httpOnly(CookieService.REFRESH_TOKEN_COOKIE, true) }
+            }
+    }
+
+    @Test
     fun `invalid otp code returns 401`() {
         seedCode("test@example.com", "123456")
 
@@ -172,37 +196,92 @@ class AuthControllerTests {
     /* ── Logout ─────────────────────────────────────────── */
 
     @Test
-    fun `logout returns 204`() {
-        mockMvc.post("/auth/logout").andExpect { status { isNoContent() } }
+    fun `logout returns 204 and clears cookies`() {
+        mockMvc
+            .post("/auth/logout") {
+                cookie(Cookie(CookieService.ACCESS_TOKEN_COOKIE, testUserToken))
+            }
+            .andExpect {
+                status { isNoContent() }
+                cookie { maxAge(CookieService.ACCESS_TOKEN_COOKIE, 0) }
+                cookie { maxAge(CookieService.REFRESH_TOKEN_COOKIE, 0) }
+            }
     }
 
-    /* ── Token Refresh ──────────────────────────────────── */
+    @Test
+    fun `logout revokes refresh tokens`() {
+        val rawRefreshToken = refreshTokenService.issueToken(testUser.id)
+        assertNotNull(
+            refreshTokenRepository.findByTokenHash(RefreshTokenService.sha256(rawRefreshToken))
+        )
+
+        mockMvc
+            .post("/auth/logout") {
+                cookie(Cookie(CookieService.ACCESS_TOKEN_COOKIE, testUserToken))
+            }
+            .andExpect { status { isNoContent() } }
+
+        assertNull(
+            refreshTokenRepository.findByTokenHash(RefreshTokenService.sha256(rawRefreshToken))
+        )
+    }
+
+    /* ── Token Refresh (cookie-based) ──────────────────── */
 
     @Test
-    fun `valid token refresh returns new token`() {
+    fun `valid refresh token cookie returns new token and sets cookies`() {
+        val rawRefreshToken = refreshTokenService.issueToken(testUser.id)
+
         mockMvc
             .post("/auth/refresh") {
-                contentType = MediaType.APPLICATION_JSON
-                content = """{"token":"$testUserToken"}"""
+                cookie(Cookie(CookieService.REFRESH_TOKEN_COOKIE, rawRefreshToken))
             }
             .andExpect {
                 status { isOk() }
                 jsonPath("$.token") { isNotEmpty() }
                 jsonPath("$.principal.username") { value("testuser") }
+                cookie { exists(CookieService.ACCESS_TOKEN_COOKIE) }
+                cookie { exists(CookieService.REFRESH_TOKEN_COOKIE) }
+                cookie { httpOnly(CookieService.ACCESS_TOKEN_COOKIE, true) }
+                cookie { httpOnly(CookieService.REFRESH_TOKEN_COOKIE, true) }
             }
     }
 
     @Test
-    fun `invalid token refresh returns 401`() {
+    fun `refresh with invalid cookie returns 401`() {
         mockMvc
             .post("/auth/refresh") {
-                contentType = MediaType.APPLICATION_JSON
-                content = """{"token":"not.a.valid.jwt"}"""
+                cookie(Cookie(CookieService.REFRESH_TOKEN_COOKIE, "not-a-valid-token"))
             }
             .andExpect {
                 status { isUnauthorized() }
-                jsonPath("$.detail") { value("Invalid or expired token") }
+                jsonPath("$.detail") { value("Invalid or expired refresh token") }
             }
+    }
+
+    @Test
+    fun `refresh without cookie returns 401`() {
+        mockMvc.post("/auth/refresh").andExpect {
+            status { isUnauthorized() }
+            jsonPath("$.detail") { value("Missing refresh token") }
+        }
+    }
+
+    @Test
+    fun `refresh token is rotated after use`() {
+        val rawRefreshToken = refreshTokenService.issueToken(testUser.id)
+
+        mockMvc
+            .post("/auth/refresh") {
+                cookie(Cookie(CookieService.REFRESH_TOKEN_COOKIE, rawRefreshToken))
+            }
+            .andExpect { status { isOk() } }
+
+        mockMvc
+            .post("/auth/refresh") {
+                cookie(Cookie(CookieService.REFRESH_TOKEN_COOKIE, rawRefreshToken))
+            }
+            .andExpect { status { isUnauthorized() } }
     }
 
     /* ── Delete Account ─────────────────────────────────── */
@@ -273,9 +352,22 @@ class AuthControllerTests {
     }
 
     @Test
-    fun `session endpoint returns principal for authenticated user`() {
+    fun `session endpoint returns principal for authenticated user via header`() {
         mockMvc
             .get("/auth/session") { header("Authorization", "Bearer $testUserToken") }
+            .andExpect {
+                status { isOk() }
+                jsonPath("$.username") { value("testuser") }
+                jsonPath("$.displayName") { value("Test User") }
+            }
+    }
+
+    @Test
+    fun `session endpoint returns principal for authenticated user via cookie`() {
+        mockMvc
+            .get("/auth/session") {
+                cookie(Cookie(CookieService.ACCESS_TOKEN_COOKIE, testUserToken))
+            }
             .andExpect {
                 status { isOk() }
                 jsonPath("$.username") { value("testuser") }

--- a/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/OidcAuthenticationSuccessHandlerTests.kt
+++ b/service-blog/src/test/kotlin/com/enigmastation/streampack/blog/controller/OidcAuthenticationSuccessHandlerTests.kt
@@ -2,11 +2,14 @@
 package com.enigmastation.streampack.blog.controller
 
 import com.enigmastation.streampack.blog.model.LoginResponse
+import com.enigmastation.streampack.blog.service.CookieService
 import com.enigmastation.streampack.blog.service.UserConvergenceService
 import com.enigmastation.streampack.core.config.StreampackProperties
 import com.enigmastation.streampack.core.model.Role
 import com.enigmastation.streampack.core.model.UserPrincipal
 import java.util.UUID
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.mockito.Mockito.mock
@@ -31,12 +34,17 @@ class OidcAuthenticationSuccessHandlerTests {
                     displayName = "Test User",
                     role = Role.USER,
                 ),
+            refreshToken = "test-refresh-token",
         )
 
     private fun mockConvergenceService(): UserConvergenceService {
         val service = mock(UserConvergenceService::class.java)
         `when`(service.converge("test@example.com", "Test User")).thenReturn(stubResponse)
         return service
+    }
+
+    private fun defaultCookieService(): CookieService {
+        return CookieService(StreampackProperties())
     }
 
     private fun oidcAuthentication(email: String): Authentication {
@@ -65,13 +73,18 @@ class OidcAuthenticationSuccessHandlerTests {
     }
 
     @Test
-    fun `redirects to frontendUrl when set`() {
+    fun `redirects to frontendUrl without token in URL`() {
         val properties =
             StreampackProperties(
                 baseUrl = "https://rest.bytecode.news",
                 frontendUrl = "https://bytecode.news",
             )
-        val handler = OidcAuthenticationSuccessHandler(mockConvergenceService(), properties)
+        val handler =
+            OidcAuthenticationSuccessHandler(
+                mockConvergenceService(),
+                defaultCookieService(),
+                properties,
+            )
 
         val response = MockHttpServletResponse()
         handler.onAuthenticationSuccess(
@@ -80,15 +93,50 @@ class OidcAuthenticationSuccessHandlerTests {
             oidcAuthentication("test@example.com"),
         )
 
-        assertTrue(
-            response.redirectedUrl!!.startsWith("https://bytecode.news/auth/callback#token=")
+        assertEquals("https://bytecode.news/auth/callback", response.redirectedUrl)
+    }
+
+    @Test
+    fun `sets authentication cookies on response`() {
+        val properties =
+            StreampackProperties(
+                baseUrl = "https://rest.bytecode.news",
+                frontendUrl = "https://bytecode.news",
+            )
+        val handler =
+            OidcAuthenticationSuccessHandler(
+                mockConvergenceService(),
+                defaultCookieService(),
+                properties,
+            )
+
+        val response = MockHttpServletResponse()
+        handler.onAuthenticationSuccess(
+            MockHttpServletRequest(),
+            response,
+            oidcAuthentication("test@example.com"),
         )
+
+        val accessCookie = response.cookies.find { it.name == CookieService.ACCESS_TOKEN_COOKIE }
+        assertNotNull(accessCookie)
+        assertEquals("test-jwt-token", accessCookie!!.value)
+        assertTrue(accessCookie.isHttpOnly)
+
+        val refreshCookie = response.cookies.find { it.name == CookieService.REFRESH_TOKEN_COOKIE }
+        assertNotNull(refreshCookie)
+        assertEquals("test-refresh-token", refreshCookie!!.value)
+        assertTrue(refreshCookie.isHttpOnly)
     }
 
     @Test
     fun `falls back to baseUrl when frontendUrl is empty`() {
         val properties = StreampackProperties(baseUrl = "https://rest.bytecode.news")
-        val handler = OidcAuthenticationSuccessHandler(mockConvergenceService(), properties)
+        val handler =
+            OidcAuthenticationSuccessHandler(
+                mockConvergenceService(),
+                defaultCookieService(),
+                properties,
+            )
 
         val response = MockHttpServletResponse()
         handler.onAuthenticationSuccess(
@@ -97,8 +145,6 @@ class OidcAuthenticationSuccessHandlerTests {
             oidcAuthentication("test@example.com"),
         )
 
-        assertTrue(
-            response.redirectedUrl!!.startsWith("https://rest.bytecode.news/auth/callback#token=")
-        )
+        assertEquals("https://rest.bytecode.news/auth/callback", response.redirectedUrl)
     }
 }

--- a/ui-nextjs/src/app/__tests__/auth-routes.test.ts
+++ b/ui-nextjs/src/app/__tests__/auth-routes.test.ts
@@ -38,11 +38,16 @@ describe("auth api routes", () => {
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.bytecode.news/auth/otp/request");
   });
 
-  it("proxies otp verify payload to backend", async () => {
+  it("proxies otp verify payload to backend and forwards Set-Cookie", async () => {
+    const backendHeaders = new Headers({
+      "content-type": "application/json",
+    });
+    backendHeaders.append("set-cookie", "access_token=jwt123; HttpOnly; Path=/");
+    backendHeaders.append("set-cookie", "refresh_token=rt456; HttpOnly; Path=/auth");
     const fetchMock = vi.fn().mockResolvedValue(
       new Response('{"token":"t","principal":{"id":"1","username":"u","displayName":"U","role":"USER"}}', {
         status: 200,
-        headers: { "content-type": "application/json" },
+        headers: backendHeaders,
       }),
     );
     vi.stubGlobal("fetch", fetchMock);
@@ -57,6 +62,8 @@ describe("auth api routes", () => {
     const response = await POST(request);
     expect(response.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.bytecode.news/auth/otp/verify");
+    const setCookies = response.headers.getSetCookie();
+    expect(setCookies.length).toBe(2);
   });
 
   it("passes authorization through logout", async () => {
@@ -119,6 +126,58 @@ describe("auth api routes", () => {
     const response = await GET(request);
     expect(response.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.bytecode.news/auth/export");
+  });
+
+  it("forwards cookies on session validation to backend", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"username":"u"}', {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { GET } = await import("@/app/api/auth/session/route");
+    const request = new Request("http://localhost:3000/api/auth/session", {
+      method: "GET",
+      headers: { Cookie: "access_token=jwt123" },
+    });
+
+    const response = await GET(request);
+    expect(response.status).toBe(200);
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Cookie")).toBe("access_token=jwt123");
+  });
+
+  it("proxies refresh token request with cookies", async () => {
+    const backendHeaders = new Headers({
+      "content-type": "application/json",
+    });
+    backendHeaders.append("set-cookie", "access_token=newjwt; HttpOnly; Path=/");
+    backendHeaders.append("set-cookie", "refresh_token=newrt; HttpOnly; Path=/auth");
+    const fetchMock = vi.fn().mockResolvedValue(
+      new Response('{"token":"newjwt","principal":{"id":"1","username":"u","displayName":"U","role":"USER"}}', {
+        status: 200,
+        headers: backendHeaders,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    const { POST } = await import("@/app/api/auth/refresh/route");
+    const request = new Request("http://localhost:3000/api/auth/refresh", {
+      method: "POST",
+      headers: { Cookie: "refresh_token=oldrt" },
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.bytecode.news/auth/refresh");
+    const init = fetchMock.mock.calls[0]?.[1] as RequestInit;
+    const headers = new Headers(init.headers);
+    expect(headers.get("Cookie")).toBe("refresh_token=oldrt");
+    const setCookies = response.headers.getSetCookie();
+    expect(setCookies.length).toBe(2);
   });
 
   it("proxies session validation to backend", async () => {

--- a/ui-nextjs/src/app/__tests__/post-submit-routes.test.ts
+++ b/ui-nextjs/src/app/__tests__/post-submit-routes.test.ts
@@ -51,7 +51,8 @@ describe("post submit api routes", () => {
     vi.stubGlobal("fetch", fetchMock);
 
     const { GET } = await import("@/app/api/categories/route");
-    const response = await GET();
+    const request = new Request("http://localhost:3000/api/categories", { method: "GET" });
+    const response = await GET(request);
 
     expect(response.status).toBe(200);
     expect(fetchMock.mock.calls[0]?.[0]).toBe("https://api.bytecode.news/categories");

--- a/ui-nextjs/src/app/api/admin/categories/[id]/route.ts
+++ b/ui-nextjs/src/app/api/admin/categories/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(
   request: Request,
@@ -12,14 +12,10 @@ export async function DELETE(
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/categories/route.ts
+++ b/ui-nextjs/src/app/api/admin/categories/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const payload = await request.text();
@@ -10,15 +10,11 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/comments/[id]/route.ts
+++ b/ui-nextjs/src/app/api/admin/comments/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(
   request: Request,
@@ -16,15 +16,11 @@ export async function DELETE(
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/posts/[id]/approve/route.ts
+++ b/ui-nextjs/src/app/api/admin/posts/[id]/approve/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(
   request: Request,
@@ -14,15 +14,11 @@ export async function PUT(
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/posts/[id]/derive-tags/route.ts
+++ b/ui-nextjs/src/app/api/admin/posts/[id]/derive-tags/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(
   request: Request,
@@ -14,15 +14,11 @@ export async function POST(
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/posts/[id]/route.ts
+++ b/ui-nextjs/src/app/api/admin/posts/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(
   request: Request,
@@ -16,15 +16,11 @@ export async function DELETE(
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/posts/derive-tags/route.ts
+++ b/ui-nextjs/src/app/api/admin/posts/derive-tags/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 const PLACEHOLDER_POST_ID = "00000000-0000-0000-0000-000000000000";
 
@@ -14,16 +14,12 @@ export async function POST(request: Request) {
         "Content-Type": "application/json",
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       body: payload,
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/posts/pending/route.ts
+++ b/ui-nextjs/src/app/api/admin/posts/pending/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -14,15 +14,11 @@ export async function GET(request: Request) {
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/[username]/purge/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/[username]/purge/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(
   request: Request,
@@ -14,15 +14,11 @@ export async function DELETE(
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/[username]/role/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/[username]/role/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(
   request: Request,
@@ -16,16 +16,12 @@ export async function PUT(
         "Content-Type": "application/json",
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       body: payload,
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/[username]/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/[username]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(
   request: Request,
@@ -12,14 +12,10 @@ export async function DELETE(
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/[username]/suspend/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/[username]/suspend/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(
   request: Request,
@@ -14,15 +14,11 @@ export async function PUT(
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/[username]/unsuspend/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/[username]/unsuspend/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(
   request: Request,
@@ -14,15 +14,11 @@ export async function PUT(
       headers: {
         Accept: "application/json",
         ...(auth ? { Authorization: auth } : {}),
+        ...forwardCookieHeader(request),
       },
       cache: "no-store",
     },
   );
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/admin/users/route.ts
+++ b/ui-nextjs/src/app/api/admin/users/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -10,14 +10,10 @@ export async function GET(request: Request) {
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/account/route.ts
+++ b/ui-nextjs/src/app/api/auth/account/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function DELETE(request: Request) {
   const payload = await request.text();
@@ -10,15 +10,11 @@ export async function DELETE(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/export/route.ts
+++ b/ui-nextjs/src/app/api/auth/export/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const auth = request.headers.get("authorization");
@@ -8,14 +8,10 @@ export async function GET(request: Request) {
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/logout/route.ts
+++ b/ui-nextjs/src/app/api/auth/logout/route.ts
@@ -1,14 +1,15 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const auth = request.headers.get("authorization");
   const response = await fetch(`${getBackendBaseUrl()}/auth/logout`, {
     method: "POST",
-    headers: auth ? { Authorization: auth } : undefined,
+    headers: {
+      ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
+    },
     cache: "no-store",
   });
 
-  return new Response(null, {
-    status: response.status,
-  });
+  return proxyResponse(response, null);
 }

--- a/ui-nextjs/src/app/api/auth/otp/request/route.ts
+++ b/ui-nextjs/src/app/api/auth/otp/request/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const payload = await request.text();
@@ -7,15 +7,11 @@ export async function POST(request: Request) {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/otp/verify/route.ts
+++ b/ui-nextjs/src/app/api/auth/otp/verify/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const payload = await request.text();
@@ -7,15 +7,11 @@ export async function POST(request: Request) {
     headers: {
       "Content-Type": "application/json",
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/profile/route.ts
+++ b/ui-nextjs/src/app/api/auth/profile/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(request: Request) {
   const payload = await request.text();
@@ -10,15 +10,11 @@ export async function PUT(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/auth/refresh/route.ts
+++ b/ui-nextjs/src/app/api/auth/refresh/route.ts
@@ -1,0 +1,18 @@
+import {
+  getBackendBaseUrl,
+  forwardCookieHeader,
+  proxyResponse,
+} from "@/lib/proxy-helpers";
+
+export async function POST(request: Request) {
+  const response = await fetch(`${getBackendBaseUrl()}/auth/refresh`, {
+    method: "POST",
+    headers: {
+      Accept: "application/json",
+      ...forwardCookieHeader(request),
+    },
+    cache: "no-store",
+  });
+
+  return proxyResponse(response, await response.text());
+}

--- a/ui-nextjs/src/app/api/auth/session/route.ts
+++ b/ui-nextjs/src/app/api/auth/session/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const auth = request.headers.get("authorization");
@@ -8,14 +8,10 @@ export async function GET(request: Request) {
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/categories/route.ts
+++ b/ui-nextjs/src/app/api/categories/route.ts
@@ -1,18 +1,14 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
-export async function GET() {
+export async function GET(request: Request) {
   const response = await fetch(`${getBackendBaseUrl()}/categories`, {
     method: "GET",
     headers: {
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/comments/[id]/route.ts
+++ b/ui-nextjs/src/app/api/comments/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function PUT(
   request: Request,
@@ -14,15 +14,11 @@ export async function PUT(
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/features/route.ts
+++ b/ui-nextjs/src/app/api/features/route.ts
@@ -1,18 +1,14 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
-export async function GET() {
+export async function GET(request: Request) {
   const response = await fetch(`${getBackendBaseUrl()}/features`, {
     method: "GET",
     headers: {
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/logs/provenances/route.ts
+++ b/ui-nextjs/src/app/api/logs/provenances/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const auth = request.headers.get("authorization");
@@ -7,14 +7,10 @@ export async function GET(request: Request) {
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/logs/route.ts
+++ b/ui-nextjs/src/app/api/logs/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -12,14 +12,10 @@ export async function GET(request: Request) {
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/post-by-id/[id]/route.ts
+++ b/ui-nextjs/src/app/api/post-by-id/[id]/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(
   request: Request,
@@ -12,16 +12,12 @@ export async function GET(
     headers: {
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }
 
 export async function PUT(
@@ -38,15 +34,11 @@ export async function PUT(
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/posts/[year]/[month]/[slug]/comments/route.ts
+++ b/ui-nextjs/src/app/api/posts/[year]/[month]/[slug]/comments/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(
   request: Request,
@@ -14,15 +14,11 @@ export async function POST(
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/posts/derive-summary/route.ts
+++ b/ui-nextjs/src/app/api/posts/derive-summary/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const payload = await request.text();
@@ -10,15 +10,11 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/posts/derive-tags/route.ts
+++ b/ui-nextjs/src/app/api/posts/derive-tags/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function POST(request: Request) {
   const payload = await request.text();
@@ -10,15 +10,11 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/posts/route.ts
+++ b/ui-nextjs/src/app/api/posts/route.ts
@@ -1,4 +1,4 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
 export async function GET(request: Request) {
   const url = new URL(request.url);
@@ -12,16 +12,12 @@ export async function GET(request: Request) {
     method: "GET",
     headers: {
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }
 
 export async function POST(request: Request) {
@@ -34,15 +30,11 @@ export async function POST(request: Request) {
       "Content-Type": "application/json",
       Accept: "application/json",
       ...(auth ? { Authorization: auth } : {}),
+      ...forwardCookieHeader(request),
     },
     body: payload,
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/api/taxonomy/route.ts
+++ b/ui-nextjs/src/app/api/taxonomy/route.ts
@@ -1,18 +1,14 @@
-import { getBackendBaseUrl } from "@/lib/backend-url";
+import { getBackendBaseUrl, forwardCookieHeader, proxyResponse } from "@/lib/proxy-helpers";
 
-export async function GET() {
+export async function GET(request: Request) {
   const response = await fetch(`${getBackendBaseUrl()}/taxonomy`, {
     method: "GET",
     headers: {
       Accept: "application/json",
+      ...forwardCookieHeader(request),
     },
     cache: "no-store",
   });
 
-  return new Response(await response.text(), {
-    status: response.status,
-    headers: {
-      "Content-Type": response.headers.get("content-type") || "application/json",
-    },
-  });
+  return proxyResponse(response, await response.text());
 }

--- a/ui-nextjs/src/app/auth/callback/page.tsx
+++ b/ui-nextjs/src/app/auth/callback/page.tsx
@@ -1,0 +1,44 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { setPrincipal, clearAuth } from "@/lib/client-auth";
+
+/**
+ * Handles the redirect after OIDC authentication.
+ * The backend has already set httpOnly cookies; this page fetches the session
+ * to store the principal for UI rendering, then redirects to the homepage.
+ */
+export default function AuthCallbackPage() {
+  const router = useRouter();
+
+  useEffect(() => {
+    async function handleCallback() {
+      try {
+        const response = await fetch("/api/auth/session", {
+          method: "GET",
+          credentials: "include",
+        });
+        if (response.ok) {
+          const principal = await response.json();
+          setPrincipal(principal);
+          router.push("/");
+          router.refresh();
+        } else {
+          clearAuth();
+          router.push("/login");
+        }
+      } catch {
+        clearAuth();
+        router.push("/login");
+      }
+    }
+    handleCallback();
+  }, [router]);
+
+  return (
+    <div className="flex min-h-[50vh] items-center justify-center">
+      <p className="byline">Completing sign-in...</p>
+    </div>
+  );
+}

--- a/ui-nextjs/src/components/__tests__/comment-create-form.test.tsx
+++ b/ui-nextjs/src/components/__tests__/comment-create-form.test.tsx
@@ -6,8 +6,7 @@ import { CommentCreateForm } from "@/components/comment-create-form";
 
 const mocks = vi.hoisted(() => ({
   authState: {
-    token: null as string | null,
-    principal: null,
+    principal: null as { id: string; username: string; displayName: string; role: string } | null,
   },
   refresh: vi.fn(),
 }));
@@ -26,14 +25,18 @@ vi.mock("@/lib/client-auth", () => ({
 afterEach(() => {
   cleanup();
   mocks.refresh.mockReset();
-  mocks.authState.token = null;
   mocks.authState.principal = null;
   vi.unstubAllGlobals();
 });
 
 describe("CommentCreateForm", () => {
   it("posts replies with parentCommentId and refreshes the page", async () => {
-    mocks.authState.token = "token-123";
+    mocks.authState.principal = {
+      id: "1",
+      username: "testuser",
+      displayName: "Test User",
+      role: "USER",
+    };
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       status: 200,
@@ -62,8 +65,8 @@ describe("CommentCreateForm", () => {
       method: "POST",
       headers: {
         "Content-Type": "application/json",
-        Authorization: "Bearer token-123",
       },
+      credentials: "include",
       body: JSON.stringify({
         markdownSource: "Nested reply body",
         parentCommentId: "parent-99",

--- a/ui-nextjs/src/components/__tests__/comment-thread.test.tsx
+++ b/ui-nextjs/src/components/__tests__/comment-thread.test.tsx
@@ -7,7 +7,6 @@ import { CommentThread } from "@/components/comment-thread";
 
 const mocks = vi.hoisted(() => ({
   authState: {
-    token: null as string | null,
     principal: null as
       | {
           id: string;
@@ -76,7 +75,6 @@ vi.mock("@/components/ui/dropdown-menu", () => ({
 afterEach(() => {
   cleanup();
   mocks.refresh.mockReset();
-  mocks.authState.token = null;
   mocks.authState.principal = null;
 });
 
@@ -122,7 +120,7 @@ describe("CommentThread", () => {
   });
 
   it("shows a nested reply form when reply is clicked", () => {
-    mocks.authState.token = "token-1";
+
     mocks.authState.principal = {
       id: "user-9",
       username: "user9",
@@ -152,7 +150,7 @@ describe("CommentThread", () => {
       editable: true,
     });
 
-    mocks.authState.token = "author-token";
+
     mocks.authState.principal = {
       id: "user-7",
       username: "author",

--- a/ui-nextjs/src/components/admin-categories.tsx
+++ b/ui-nextjs/src/components/admin-categories.tsx
@@ -56,7 +56,7 @@ export function AdminCategories() {
 
   async function onCreate(event: FormEvent) {
     event.preventDefault();
-    if (!auth.token) return;
+    if (!auth.principal) return;
 
     setBusy(true);
     setStatus(null);
@@ -66,8 +66,8 @@ export function AdminCategories() {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({
           name: name.trim(),
           parentId: parentId || null,
@@ -90,7 +90,7 @@ export function AdminCategories() {
   }
 
   async function onDelete(id: string, categoryName: string) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     if (!window.confirm(`Delete the "${categoryName}" category?`)) return;
 
     setBusy(true);
@@ -99,9 +99,7 @@ export function AdminCategories() {
     try {
       const response = await fetch(`/api/admin/categories/${encodeURIComponent(id)}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
-        },
+        credentials: "include",
       });
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
@@ -116,7 +114,7 @@ export function AdminCategories() {
     }
   }
 
-  if (!auth.token || !isAdmin) {
+  if (!auth.principal || !isAdmin) {
     return (
       <div className="py-12 text-center">
         <p className="section-label text-muted-foreground">

--- a/ui-nextjs/src/components/admin-dashboard.tsx
+++ b/ui-nextjs/src/components/admin-dashboard.tsx
@@ -66,37 +66,32 @@ export function AdminDashboard() {
     auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
 
   useEffect(() => {
-    if (!auth.token || !isAdmin) {
+    if (!auth.principal || !isAdmin) {
       setLoading(false);
       return;
     }
 
     async function load() {
-      const headers = {
-        Accept: "application/json",
-        Authorization: `Bearer ${auth.token}`,
+      const authedOpts = {
+        headers: { Accept: "application/json" },
+        credentials: "include" as RequestCredentials,
+        cache: "no-store" as RequestCache,
       };
 
       const results = await Promise.allSettled([
-        fetch("/api/admin/posts/pending?page=0&size=1&deleted=false", {
-          headers,
-          cache: "no-store",
-        }).then((r) => r.json() as Promise<ContentListResponse>),
+        fetch("/api/admin/posts/pending?page=0&size=1&deleted=false", authedOpts)
+          .then((r) => r.json() as Promise<ContentListResponse>),
 
         fetch("/api/posts?page=0&size=1", {
           headers: { Accept: "application/json" },
           cache: "no-store",
         }).then((r) => r.json() as Promise<ContentListResponse>),
 
-        fetch("/api/admin/users?status=ACTIVE", {
-          headers,
-          cache: "no-store",
-        }).then((r) => r.json() as Promise<UserPrincipal[]>),
+        fetch("/api/admin/users?status=ACTIVE", authedOpts)
+          .then((r) => r.json() as Promise<UserPrincipal[]>),
 
-        fetch("/api/admin/users?status=SUSPENDED", {
-          headers,
-          cache: "no-store",
-        }).then((r) => r.json() as Promise<UserPrincipal[]>),
+        fetch("/api/admin/users?status=SUSPENDED", authedOpts)
+          .then((r) => r.json() as Promise<UserPrincipal[]>),
 
         fetch("/api/categories", {
           headers: { Accept: "application/json" },
@@ -136,7 +131,7 @@ export function AdminDashboard() {
     void load();
   }, []); // eslint-disable-line react-hooks/exhaustive-deps
 
-  if (!auth.token || !isAdmin) {
+  if (!auth.principal || !isAdmin) {
     return (
       <div className="py-12 text-center">
         <p className="section-label text-muted-foreground">

--- a/ui-nextjs/src/components/admin-pending-posts.tsx
+++ b/ui-nextjs/src/components/admin-pending-posts.tsx
@@ -111,7 +111,7 @@ export function AdminPendingPosts() {
     auth.principal?.role === "SUPER_ADMIN";
 
   const loadPending = useCallback(async () => {
-    if (!auth.token || !isAdmin) {
+    if (!auth.principal || !isAdmin) {
       setLoading(false);
       return;
     }
@@ -123,8 +123,8 @@ export function AdminPendingPosts() {
         {
           headers: {
             Accept: "application/json",
-            Authorization: `Bearer ${auth.token}`,
           },
+          credentials: "include",
           cache: "no-store",
         },
       );
@@ -145,14 +145,14 @@ export function AdminPendingPosts() {
     } finally {
       setLoading(false);
     }
-  }, [auth.token, isAdmin, showDeleted]);
+  }, [auth.principal, isAdmin, showDeleted]);
 
   useEffect(() => {
     void loadPending();
   }, [loadPending]);
 
   async function approve(postId: string) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setBusyId(postId);
     setStatus(null);
     setError(null);
@@ -161,8 +161,8 @@ export function AdminPendingPosts() {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ publishedAt: new Date().toISOString() }),
       });
       const payload = (await response.json()) as unknown;
@@ -188,7 +188,7 @@ export function AdminPendingPosts() {
       : "Delete this draft? It can be restored later.";
     if (!window.confirm(message)) return;
 
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setBusyId(postId);
     setStatus(null);
     setError(null);
@@ -197,9 +197,7 @@ export function AdminPendingPosts() {
         `/api/admin/posts/${postId}?hard=${hard ? "true" : "false"}`,
         {
           method: "DELETE",
-          headers: {
-            Authorization: `Bearer ${auth.token}`,
-          },
+          credentials: "include",
         },
       );
       const payload = (await response.json()) as unknown;
@@ -220,14 +218,14 @@ export function AdminPendingPosts() {
   }
 
   async function openPreview(postId: string) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setPreviewLoading(postId);
     try {
       const response = await fetch(`/api/post-by-id/${postId}`, {
         headers: {
           Accept: "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         cache: "no-store",
       });
       const payload = (await response.json()) as unknown;
@@ -246,7 +244,7 @@ export function AdminPendingPosts() {
     }
   }
 
-  if (!auth.token || !isAdmin) {
+  if (!auth.principal || !isAdmin) {
     return (
       <div className="py-12 text-center">
         <p className="section-label text-muted-foreground">

--- a/ui-nextjs/src/components/admin-users.tsx
+++ b/ui-nextjs/src/components/admin-users.tsx
@@ -37,16 +37,14 @@ export function AdminUsers() {
   const [notice, setNotice] = useState<string | null>(null);
 
   async function loadUsers(nextStatus: UserStatus) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setLoading(true);
     setError(null);
     setNotice(null);
     setStatus(nextStatus);
     try {
       const response = await fetch(`/api/admin/users?status=${nextStatus}`, {
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
-        },
+        credentials: "include",
         cache: "no-store",
       });
       const payload = (await response.json()) as unknown;
@@ -73,15 +71,13 @@ export function AdminUsers() {
     confirmMessage?: string,
   ) {
     if (confirmMessage && !window.confirm(confirmMessage)) return;
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setError(null);
     setNotice(null);
     try {
       const response = await fetch(path, {
         method,
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
-        },
+        credentials: "include",
       });
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
@@ -95,7 +91,7 @@ export function AdminUsers() {
   }
 
   async function changeRole(username: string, newRole: Role) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setError(null);
     setNotice(null);
     try {
@@ -103,8 +99,8 @@ export function AdminUsers() {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ newRole }),
       });
       const payload = (await response.json()) as unknown;
@@ -118,7 +114,7 @@ export function AdminUsers() {
     }
   }
 
-  if (!auth.token || !isAdmin) {
+  if (!auth.principal || !isAdmin) {
     return (
       <div className="py-12 text-center">
         <p className="section-label text-muted-foreground">

--- a/ui-nextjs/src/components/auth-nav.tsx
+++ b/ui-nextjs/src/components/auth-nav.tsx
@@ -62,11 +62,10 @@ export function AuthNav({ allowAnonymousSubmission = false }: AuthNavProps) {
 
   async function onLogout(event: MouseEvent<HTMLAnchorElement>) {
     event.preventDefault();
-    const token = getAuthState().token;
     try {
       await fetch("/api/auth/logout", {
         method: "POST",
-        headers: token ? { Authorization: `Bearer ${token}` } : undefined,
+        credentials: "include",
       });
     } catch {
       // Clear local auth even if backend is temporarily unavailable.
@@ -76,7 +75,7 @@ export function AuthNav({ allowAnonymousSubmission = false }: AuthNavProps) {
     }
   }
 
-  if (!auth.token || !auth.principal) {
+  if (!auth.principal) {
     return (
       <div className="inline-flex items-center gap-1">
         {allowAnonymousSubmission && (

--- a/ui-nextjs/src/components/comment-create-form.tsx
+++ b/ui-nextjs/src/components/comment-create-form.tsx
@@ -24,7 +24,7 @@ export function CommentCreateForm({ year, month, slug, parentCommentId, onCancel
 
   async function onSubmit(event: FormEvent) {
     event.preventDefault();
-    if (!auth.token) {
+    if (!auth.principal) {
       setError("Sign in to comment.");
       return;
     }
@@ -38,8 +38,8 @@ export function CommentCreateForm({ year, month, slug, parentCommentId, onCancel
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ markdownSource, parentCommentId: parentCommentId || undefined }),
       });
 
@@ -58,7 +58,7 @@ export function CommentCreateForm({ year, month, slug, parentCommentId, onCancel
     }
   }
 
-  if (!auth.token) {
+  if (!auth.principal) {
     return (
       <p>
         <Link className="pagelink" href={`/login?return=/posts/${year}/${month}/${slug}`}>

--- a/ui-nextjs/src/components/comment-thread.tsx
+++ b/ui-nextjs/src/components/comment-thread.tsx
@@ -25,7 +25,7 @@ interface CommentThreadProps {
 interface CommentItemProps {
   node: CommentNode;
   isAdmin: boolean;
-  token: string | null;
+  loggedIn: boolean;
   userId: string | null;
   year: string;
   month: string;
@@ -41,7 +41,7 @@ function htmlToText(html: string): string {
   return node.textContent?.trim() || "";
 }
 
-function CommentItem({ node, isAdmin, token, userId, year, month, slug }: CommentItemProps) {
+function CommentItem({ node, isAdmin, loggedIn, userId, year, month, slug }: CommentItemProps) {
   const router = useRouter();
   const [editing, setEditing] = useState(false);
   const [replying, setReplying] = useState(false);
@@ -53,7 +53,7 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
 
   async function onSaveEdit(event: FormEvent) {
     event.preventDefault();
-    if (!token) {
+    if (!loggedIn) {
       setError("Sign in to edit comments.");
       return;
     }
@@ -66,8 +66,8 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ markdownSource }),
       });
       const payload = (await response.json()) as { detail?: string; title?: string };
@@ -85,7 +85,7 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
   }
 
   async function onDelete() {
-    if (!token) {
+    if (!loggedIn) {
       setError("Sign in to moderate comments.");
       return;
     }
@@ -100,9 +100,7 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
     try {
       const response = await fetch(`/api/admin/comments/${node.id}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
+        credentials: "include",
       });
       const payload = (await response.json()) as { detail?: string; title?: string };
       if (!response.ok) {
@@ -156,7 +154,7 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
         <HighlightedHtml className="post-body comment-body" html={node.renderedHtml} />
       )}
 
-      {token && !node.deleted && !replying && !editing ? (
+      {loggedIn && !node.deleted && !replying && !editing ? (
         <div className="comment-actions-row">
           <button
             type="button"
@@ -219,7 +217,7 @@ function CommentItem({ node, isAdmin, token, userId, year, month, slug }: Commen
       {node.children.length > 0 ? (
         <div className="comment-children">
           {node.children.map((child) => (
-            <CommentItem key={child.id} node={child} isAdmin={isAdmin} token={token} userId={userId} year={year} month={month} slug={slug} />
+            <CommentItem key={child.id} node={child} isAdmin={isAdmin} loggedIn={loggedIn} userId={userId} year={year} month={month} slug={slug} />
           ))}
         </div>
       ) : null}
@@ -233,7 +231,7 @@ export function CommentThread({ comments, year, month, slug }: CommentThreadProp
   return (
     <>
       {comments.map((comment) => (
-        <CommentItem key={comment.id} node={comment} isAdmin={isAdmin} token={auth.token} userId={auth.principal?.id ?? null} year={year} month={month} slug={slug} />
+        <CommentItem key={comment.id} node={comment} isAdmin={isAdmin} loggedIn={auth.principal != null} userId={auth.principal?.id ?? null} year={year} month={month} slug={slug} />
       ))}
     </>
   );

--- a/ui-nextjs/src/components/edit-post-form.tsx
+++ b/ui-nextjs/src/components/edit-post-form.tsx
@@ -94,7 +94,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
 
   useEffect(() => {
     async function load() {
-      if (!auth.token) {
+      if (!auth.principal) {
         setError("Sign in to edit posts.");
         setLoading(false);
         return;
@@ -104,8 +104,8 @@ export function EditPostForm({ postId }: EditPostFormProps) {
         const response = await fetch(`/api/post-by-id/${postId}`, {
           headers: {
             Accept: "application/json",
-            Authorization: `Bearer ${auth.token}`,
           },
+          credentials: "include",
           cache: "no-store",
         });
 
@@ -135,7 +135,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
     }
 
     void load();
-  }, [postId, auth.token]);
+  }, [postId, auth.principal]);
 
   useEffect(() => {
     void (async () => {
@@ -154,7 +154,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
   }, []);
 
   async function save() {
-    if (!auth.token) {
+    if (!auth.principal) {
       setError("Sign in to edit posts.");
       return false;
     }
@@ -185,8 +185,8 @@ export function EditPostForm({ postId }: EditPostFormProps) {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({
           title,
           markdownSource,
@@ -221,7 +221,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
   }
 
   async function applyTags(path: string, mode: "heuristic" | "ai") {
-    if (!auth.token) {
+    if (!auth.principal) {
       setError("Sign in to derive tags.");
       return;
     }
@@ -233,8 +233,8 @@ export function EditPostForm({ postId }: EditPostFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({
           title: title.trim(),
           markdownSource: markdownSource.trim(),
@@ -269,7 +269,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
   }
 
   async function applySummary() {
-    if (!auth.token) {
+    if (!auth.principal) {
       setError("Sign in to derive a summary.");
       return;
     }
@@ -281,8 +281,8 @@ export function EditPostForm({ postId }: EditPostFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({
           title: title.trim(),
           markdownSource: markdownSource.trim(),
@@ -307,7 +307,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
   }
 
   async function approveNow() {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     const ok = await save();
     if (!ok) return;
     setBusy(true);
@@ -318,8 +318,8 @@ export function EditPostForm({ postId }: EditPostFormProps) {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({
           publishedAt: publishedAtInput ? new Date(publishedAtInput).toISOString() : new Date().toISOString(),
         }),
@@ -342,16 +342,14 @@ export function EditPostForm({ postId }: EditPostFormProps) {
   }
 
   async function deletePost(hard: boolean) {
-    if (!auth.token) return;
+    if (!auth.principal) return;
     setBusy(true);
     setError(null);
     setStatus(null);
     try {
       const response = await fetch(`/api/admin/posts/${postId}?hard=${hard ? "true" : "false"}`, {
         method: "DELETE",
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
-        },
+        credentials: "include",
       });
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
@@ -370,7 +368,7 @@ export function EditPostForm({ postId }: EditPostFormProps) {
     await save();
   }
 
-  if (!auth.token) {
+  if (!auth.principal) {
     return (
       <section className="notice">
         <h2>Edit Post</h2>

--- a/ui-nextjs/src/components/logs-browser.tsx
+++ b/ui-nextjs/src/components/logs-browser.tsx
@@ -108,7 +108,7 @@ export function LogsBrowser() {
       setProvenanceError(null);
       try {
         const response = await fetch("/api/logs/provenances", {
-          headers: auth.token ? { Authorization: `Bearer ${auth.token}` } : undefined,
+          credentials: "include",
           cache: "no-store",
         });
         const payload = (await response.json()) as unknown;
@@ -124,7 +124,7 @@ export function LogsBrowser() {
       }
     }
     void loadProvenances();
-  }, [auth.token]);
+  }, [auth.principal]);
 
   useEffect(() => {
     if (!selectedProvenance) return;
@@ -149,7 +149,7 @@ export function LogsBrowser() {
         const response = await fetch(
           `/api/logs?provenance=${encodeURIComponent(selectedProvenance)}&day=${encodeURIComponent(day)}`,
           {
-            headers: auth.token ? { Authorization: `Bearer ${auth.token}` } : undefined,
+            credentials: "include",
             cache: "no-store",
           },
         );
@@ -167,7 +167,7 @@ export function LogsBrowser() {
     }
 
     void loadLogs();
-  }, [selectedProvenance, day, auth.token]);
+  }, [selectedProvenance, day, auth.principal]);
 
   const today = utcToday();
   const previousDay = shiftDay(day, -1);

--- a/ui-nextjs/src/components/otp-login-form.tsx
+++ b/ui-nextjs/src/components/otp-login-form.tsx
@@ -50,6 +50,7 @@ export function OtpLoginForm({
       const response = await fetch("/api/auth/otp/request", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email }),
       });
 
@@ -76,6 +77,7 @@ export function OtpLoginForm({
       const response = await fetch("/api/auth/otp/verify", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify({ email, code }),
       });
 

--- a/ui-nextjs/src/components/post-actions.tsx
+++ b/ui-nextjs/src/components/post-actions.tsx
@@ -10,7 +10,7 @@ interface PostActionsProps {
 export function PostActions({ postId }: PostActionsProps) {
   const auth = getAuthState();
   const isAdmin = auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
-  if (!auth.token || !isAdmin) return null;
+  if (!auth.principal || !isAdmin) return null;
 
   return (
     <p>

--- a/ui-nextjs/src/components/profile-form.tsx
+++ b/ui-nextjs/src/components/profile-form.tsx
@@ -22,7 +22,7 @@ export function ProfileForm() {
   const [status, setStatus] = useState<string | null>(null);
   const [error, setError] = useState<string | null>(null);
 
-  if (!auth.token || !auth.principal) {
+  if (!auth.principal) {
     return (
       <section className="py-8 md:py-12">
         <div className="max-w-2xl mx-auto px-6 md:px-8">
@@ -51,8 +51,8 @@ export function ProfileForm() {
         method: "PUT",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ displayName: displayName.trim() }),
       });
       const payload = (await response.json()) as unknown;
@@ -76,9 +76,7 @@ export function ProfileForm() {
     try {
       const response = await fetch("/api/auth/export", {
         method: "GET",
-        headers: {
-          Authorization: `Bearer ${auth.token}`,
-        },
+        credentials: "include",
       });
       const payload = (await response.json()) as unknown;
       if (!response.ok) {
@@ -112,8 +110,8 @@ export function ProfileForm() {
         method: "DELETE",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({}),
       });
       const payload = (await response.json()) as unknown;

--- a/ui-nextjs/src/components/submit-post-form.tsx
+++ b/ui-nextjs/src/components/submit-post-form.tsx
@@ -60,13 +60,13 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
   const loadedAt = useMemo(() => Date.now(), []);
 
   const auth = getAuthState();
-  const canSubmit = anonymousSubmission || Boolean(auth.token);
+  const canSubmit = anonymousSubmission || Boolean(auth.principal);
   const canDeriveAiTags =
     auth.principal?.role === "ADMIN" || auth.principal?.role === "SUPER_ADMIN";
   const isAdmin = canDeriveAiTags;
   const canSuggestTags = title.trim().length > 0 && markdownSource.trim().length > 0 && !busy;
   const canDeriveSummary =
-    Boolean(auth.token) && title.trim().length > 0 && markdownSource.trim().length > 0 && !busy;
+    Boolean(auth.principal) && title.trim().length > 0 && markdownSource.trim().length > 0 && !busy;
 
   function splitCategories(value: string): string[] {
     return value
@@ -114,8 +114,8 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(auth.token ? { Authorization: `Bearer ${auth.token}` } : {}),
         },
+        credentials: "include",
         body: JSON.stringify({
           title: titleValue,
           markdownSource: markdownValue,
@@ -165,7 +165,7 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
   async function applyDerivedSummary(): Promise<void> {
     const titleValue = title.trim();
     const markdownValue = markdownSource.trim();
-    if (!auth.token) {
+    if (!auth.principal) {
       setError("Sign in to derive a summary.");
       setStatus(null);
       return;
@@ -189,8 +189,8 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: `Bearer ${auth.token}`,
         },
+        credentials: "include",
         body: JSON.stringify({ title: titleValue, markdownSource: markdownValue }),
       });
       const payload = (await response.json()) as SummaryResponse & ProblemLike;
@@ -243,14 +243,14 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          ...(auth.token ? { Authorization: `Bearer ${auth.token}` } : {}),
         },
+        credentials: "include",
         body: JSON.stringify({
           title,
           markdownSource,
           tags: splitTags(tagsInput),
           categoryIds,
-          ...(auth.token ? { summary } : {}),
+          ...(auth.principal ? { summary } : {}),
           formLoadedAt: loadedAt,
         }),
       });
@@ -405,7 +405,7 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
           </div>
 
           {/* Summary (authenticated users only) */}
-          {auth.token && (
+          {auth.principal && (
             <div className="mb-6">
               <div className="flex items-center justify-between mb-1.5">
                 <label className="byline text-muted-foreground/50" htmlFor="post-summary">

--- a/ui-nextjs/src/lib/__tests__/client-auth.test.ts
+++ b/ui-nextjs/src/lib/__tests__/client-auth.test.ts
@@ -70,14 +70,14 @@ describe("client auth", () => {
     }
   });
 
-  it("returns no-token when there is no stored auth token", async () => {
+  it("returns no-token when there is no stored principal", async () => {
     const fetcher = vi.fn();
     const result = await validateAuthSession(fetcher as unknown as typeof fetch);
     expect(result).toBe("no-token");
     expect(fetcher).not.toHaveBeenCalled();
   });
 
-  it("returns valid when backend accepts auth token", async () => {
+  it("returns valid when backend accepts session cookie", async () => {
     setAuth({
       token: "abc",
       principal: { id: "1", username: "dreamreal", displayName: "dreamreal", role: "USER" },
@@ -86,20 +86,44 @@ describe("client auth", () => {
     const fetcher = vi.fn().mockResolvedValue(new Response("{}", { status: 200 }));
     const result = await validateAuthSession(fetcher as unknown as typeof fetch);
     expect(result).toBe("valid");
-    expect(getAuthState().token).toBe("abc");
+    expect(getAuthState().principal).not.toBeNull();
   });
 
-  it("clears auth and reports expired when backend returns 401", async () => {
+  it("attempts silent refresh on 401 before clearing auth", async () => {
     setAuth({
       token: "abc",
       principal: { id: "1", username: "dreamreal", displayName: "dreamreal", role: "USER" },
     });
 
-    const fetcher = vi.fn().mockResolvedValue(new Response("{}", { status: 401 }));
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response("{}", { status: 401 }))
+      .mockResolvedValueOnce(new Response("{}", { status: 401 }));
     const result = await validateAuthSession(fetcher as unknown as typeof fetch);
     expect(result).toBe("expired");
-    expect(getAuthState().token).toBeNull();
     expect(getAuthState().principal).toBeNull();
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it("returns refreshed when silent refresh succeeds after 401", async () => {
+    setAuth({
+      token: "abc",
+      principal: { id: "1", username: "dreamreal", displayName: "dreamreal", role: "USER" },
+    });
+
+    const fetcher = vi.fn()
+      .mockResolvedValueOnce(new Response("{}", { status: 401 }))
+      .mockResolvedValueOnce(
+        new Response(
+          JSON.stringify({
+            token: "new-token",
+            principal: { id: "1", username: "dreamreal", displayName: "dreamreal", role: "USER" },
+          }),
+          { status: 200 },
+        ),
+      );
+    const result = await validateAuthSession(fetcher as unknown as typeof fetch);
+    expect(result).toBe("refreshed");
+    expect(getAuthState().principal).not.toBeNull();
   });
 
   it("reports network-error on fetch failure without clearing auth", async () => {
@@ -111,7 +135,7 @@ describe("client auth", () => {
     const fetcher = vi.fn().mockRejectedValue(new Error("offline"));
     const result = await validateAuthSession(fetcher as unknown as typeof fetch);
     expect(result).toBe("network-error");
-    expect(getAuthState().token).toBe("abc");
+    expect(getAuthState().principal).not.toBeNull();
     clearAuth();
   });
 });

--- a/ui-nextjs/src/lib/client-auth.ts
+++ b/ui-nextjs/src/lib/client-auth.ts
@@ -15,13 +15,11 @@ export interface LoginResponse {
 }
 
 interface AuthState {
-  token: string | null;
   principal: UserPrincipal | null;
 }
 
-type SessionValidationResult = "no-token" | "valid" | "expired" | "network-error";
+type SessionValidationResult = "no-token" | "valid" | "refreshed" | "expired" | "network-error";
 
-const TOKEN_KEY = "ui_nextjs_token";
 const PRINCIPAL_KEY = "ui_nextjs_principal";
 const AUTH_EVENT = "ui-nextjs-auth-change";
 
@@ -37,14 +35,16 @@ function parsePrincipal(raw: string | null): UserPrincipal | null {
   }
 }
 
+/** Returns the current auth state (principal only; tokens are in httpOnly cookies) */
 export function getAuthState(): AuthState {
   if (typeof window === "undefined") {
-    return { token: null, principal: null };
+    return { principal: null };
   }
 
-  const token = window.localStorage.getItem(TOKEN_KEY);
-  const principal = parsePrincipal(window.localStorage.getItem(PRINCIPAL_KEY));
-  return { token, principal };
+  const principal = parsePrincipal(
+    window.localStorage.getItem(PRINCIPAL_KEY),
+  );
+  return { principal };
 }
 
 function notifyAuthChange(): void {
@@ -53,15 +53,19 @@ function notifyAuthChange(): void {
   }
 }
 
+/** Stores the principal from a successful login (tokens are set as httpOnly cookies by the backend) */
 export function setAuth(login: LoginResponse): void {
   if (typeof window === "undefined") {
     return;
   }
-  window.localStorage.setItem(TOKEN_KEY, login.token);
-  window.localStorage.setItem(PRINCIPAL_KEY, JSON.stringify(login.principal));
+  window.localStorage.setItem(
+    PRINCIPAL_KEY,
+    JSON.stringify(login.principal),
+  );
   notifyAuthChange();
 }
 
+/** Updates just the principal (for profile changes) */
 export function setPrincipal(principal: UserPrincipal): void {
   if (typeof window === "undefined") {
     return;
@@ -70,11 +74,11 @@ export function setPrincipal(principal: UserPrincipal): void {
   notifyAuthChange();
 }
 
+/** Clears the local principal (cookies are cleared by the logout endpoint) */
 export function clearAuth(): void {
   if (typeof window === "undefined") {
     return;
   }
-  window.localStorage.removeItem(TOKEN_KEY);
   window.localStorage.removeItem(PRINCIPAL_KEY);
   notifyAuthChange();
 }
@@ -92,20 +96,53 @@ export function onAuthChange(handler: () => void): () => void {
   };
 }
 
+/** Attempts a silent token refresh via the refresh token cookie */
+async function attemptSilentRefresh(
+  fetcher: typeof fetch = fetch,
+): Promise<boolean> {
+  try {
+    const response = await fetcher("/api/auth/refresh", {
+      method: "POST",
+      credentials: "include",
+    });
+    if (response.ok) {
+      const data = await response.json();
+      if (data.principal) {
+        setPrincipal(data.principal);
+      }
+      return true;
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Validates the current session. If the access token has expired, attempts a silent refresh
+ * using the refresh token cookie before clearing auth.
+ */
 export async function validateAuthSession(
   fetcher: typeof fetch = fetch,
 ): Promise<SessionValidationResult> {
-  const { token } = getAuthState();
-  if (!token) {
+  const { principal } = getAuthState();
+  if (!principal) {
     return "no-token";
   }
 
   try {
     const response = await fetcher("/api/auth/session", {
       method: "GET",
-      headers: { Authorization: `Bearer ${token}` },
+      credentials: "include",
     });
+    if (response.ok) {
+      return "valid";
+    }
     if (response.status === 401 || response.status === 403) {
+      const refreshed = await attemptSilentRefresh(fetcher);
+      if (refreshed) {
+        return "refreshed";
+      }
       clearAuth();
       return "expired";
     }

--- a/ui-nextjs/src/lib/proxy-helpers.ts
+++ b/ui-nextjs/src/lib/proxy-helpers.ts
@@ -1,0 +1,42 @@
+import { getBackendBaseUrl } from "@/lib/backend-url";
+
+/** Extracts the Cookie header from the incoming request for forwarding to the backend */
+export function forwardCookieHeader(
+  request: Request,
+): Record<string, string> {
+  const cookie = request.headers.get("cookie");
+  return cookie ? { Cookie: cookie } : {};
+}
+
+/** Creates a Response that forwards Set-Cookie headers from the backend to the client */
+export function proxyResponse(
+  backendResponse: Response,
+  body: string | null,
+): Response {
+  const headers = new Headers();
+  const contentType = backendResponse.headers.get("content-type");
+  if (contentType) {
+    headers.set("Content-Type", contentType);
+  }
+  for (const cookie of backendResponse.headers.getSetCookie()) {
+    headers.append("Set-Cookie", cookie);
+  }
+  return new Response(body, { status: backendResponse.status, headers });
+}
+
+/** Builds the standard headers for a proxied request, forwarding auth and cookies */
+export function proxyHeaders(
+  request: Request,
+  options?: { contentType?: boolean },
+): Record<string, string> {
+  const auth = request.headers.get("authorization");
+  return {
+    Accept: "application/json",
+    ...(options?.contentType !== false ? { "Content-Type": "application/json" } : {}),
+    ...(auth ? { Authorization: auth } : {}),
+    ...forwardCookieHeader(request),
+  };
+}
+
+/** Returns the backend base URL (re-exported for convenience) */
+export { getBackendBaseUrl };


### PR DESCRIPTION
## Summary

Resolves #339

- Adds DB-backed rotating refresh tokens (30-day TTL, one-time use) so users stay logged in across browser restarts without re-authenticating via OTP
- Moves JWT and refresh tokens into httpOnly Secure SameSite=Strict cookies, eliminating the XSS vulnerability of localStorage token storage
- Frontend silently refreshes expired JWTs using the refresh token cookie before falling back to re-login
- Backward-compatible: API consumers can still use `Authorization: Bearer` headers

## Changes

**Backend (Kotlin/Spring Boot):**
- Flyway V33 migration: `refresh_tokens` table with hashed token storage
- `RefreshTokenService`: issue, rotate (one-time use), revoke, cleanup
- `CookieService`: httpOnly cookie creation/clearing
- `AuthController`: cookie-based session validation, refresh endpoint reads cookie, logout revokes tokens + clears cookies
- `OidcAuthenticationSuccessHandler`: sets cookies before redirect instead of JWT in URL fragment
- CORS: `allowCredentials=true`, Cookie/Set-Cookie headers

**Frontend (Next.js/TypeScript):**
- `proxy-helpers.ts`: shared Cookie/Set-Cookie forwarding for all API route handlers
- All ~30 API route handlers updated to forward cookies both directions
- `client-auth.ts`: principal-only localStorage, silent refresh on 401
- All components switched from `Authorization` header to `credentials: "include"`
- New `/auth/callback` page for OIDC cookie-based flow
- New `/api/auth/refresh` proxy route

## Test plan

- [ ] Backend: `./mvnw test -pl lib-core,service-blog` (320+ lib-core tests, 205 service-blog tests)
- [ ] Frontend: `cd ui-nextjs && npm test` (94 tests)
- [ ] Manual: Login via OTP, verify `access_token` and `refresh_token` httpOnly cookies in DevTools
- [ ] Manual: Delete `access_token` cookie, trigger session check — silent refresh restores it
- [ ] Manual: Logout — both cookies cleared, refresh tokens revoked
- [ ] Manual: `document.cookie` does not expose tokens (httpOnly)
- [ ] Manual: API consumers can still use `Authorization: Bearer` header