### PR TITLE
Add custom GA4 event tracking for login, comments, and drafts

### DIFF
--- a/ui-nextjs/src/components/comment-create-form.tsx
+++ b/ui-nextjs/src/components/comment-create-form.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { getAuthState } from "@/lib/client-auth";
+import { trackEvent } from "@/lib/analytics";
 
 interface CommentCreateFormProps {
   year: string;
@@ -49,6 +50,7 @@ export function CommentCreateForm({ year, month, slug, parentCommentId, onCancel
 
       setMarkdownSource("");
       setStatus("Comment posted.");
+      trackEvent("comment_submit", { slug, is_reply: parentCommentId ? 1 : 0 });
       if (onCancel) onCancel();
       router.refresh();
     } catch (submitError) {

--- a/ui-nextjs/src/components/otp-login-form.tsx
+++ b/ui-nextjs/src/components/otp-login-form.tsx
@@ -3,6 +3,7 @@
 import { useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { LoginResponse, setAuth } from "@/lib/client-auth";
+import { trackEvent } from "@/lib/analytics";
 
 interface OtpLoginFormProps {
   returnPath: string;
@@ -87,6 +88,7 @@ export function OtpLoginForm({
 
       const login = (await response.json()) as LoginResponse;
       setAuth(login);
+      trackEvent("login", { method: "otp" });
       setStatus("Signed in.");
       router.push(normalizedReturnPath);
       router.refresh();

--- a/ui-nextjs/src/components/submit-post-form.tsx
+++ b/ui-nextjs/src/components/submit-post-form.tsx
@@ -3,6 +3,7 @@
 import { FormEvent, useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { getAuthState } from "@/lib/client-auth";
+import { trackEvent } from "@/lib/analytics";
 import { MarkdownPreview } from "@/components/markdown-preview";
 
 interface SubmitPostFormProps {
@@ -262,6 +263,7 @@ export function SubmitPostForm({ anonymousSubmission }: SubmitPostFormProps) {
       const created = (await response.json()) as { id?: string; title: string; status: string };
       setStatus(`Draft saved: "${created.title}" (${created.status}).`);
       setCreatedPostId(created.id || null);
+      trackEvent("draft_submit", { status: created.status });
       setTitle("");
       setMarkdownSource("");
       setSummary("");

--- a/ui-nextjs/src/lib/analytics.ts
+++ b/ui-nextjs/src/lib/analytics.ts
@@ -1,0 +1,14 @@
+declare global {
+  interface Window {
+    gtag?: (...args: [string, ...unknown[]]) => void;
+  }
+}
+
+/**
+ * Sends a custom event to Google Analytics via gtag.
+ */
+export function trackEvent(name: string, params?: Record<string, string | number>) {
+  if (typeof window !== "undefined" && typeof window.gtag === "function") {
+    window.gtag("event", name, params);
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `trackEvent()` utility in `src/lib/analytics.ts` wrapping `window.gtag` with TypeScript types
- Fires `login` event (with `method: otp`) after successful OTP verification
- Fires `comment_submit` event (with `slug`, `is_reply`) after successful comment POST
- Fires `draft_submit` event (with `status`) after successful draft POST
- All events fire only on confirmed API success, not on attempts or errors

## Known gaps
- OAuth login (Google/GitHub) is not tracked -- these methods aren't active right now. When enabled, an event should be added to `auth/callback/page.tsx`.
- Consent Mode v2 is not addressed here.

## Test plan
- [ ] Deploy to staging, open GA4 Realtime > Events
- [ ] Log in via OTP and confirm `login` event appears
- [ ] Post a comment on any article and confirm `comment_submit` event appears with correct slug
- [ ] Submit a draft and confirm `draft_submit` event appears
- [ ] Verify no events fire on failed attempts (wrong OTP code, empty comment, etc.)
- [ ] Verify site works normally with `NEXT_PUBLIC_GA_MEASUREMENT_ID` unset (trackEvent no-ops)

Closes #362